### PR TITLE
Fix/type inference array init and tuple return

### DIFF
--- a/manual_test.coffee
+++ b/manual_test.coffee
@@ -30,11 +30,12 @@ process_file = (file)->
       p "FLAG need_prevent_deploy"
   
   if argv.full
-    new_ast = ast_transform.ligo_pack new_ast, {
+    opt = {
       router  : argv.router
     }
+    new_ast = ast_transform.ligo_pack new_ast, opt
     new_ast = type_inference new_ast
-    code = translate new_ast
+    code = translate new_ast, opt
     if argv.print
       puts code
     

--- a/src/ast.coffee
+++ b/src/ast.coffee
@@ -145,6 +145,7 @@ class @Comment
 
 class @Tuple
   list : []
+  type : null
   line : 0
   pos  : 0
   
@@ -155,6 +156,7 @@ class @Tuple
     ret = new module.Tuple
     for v in @list
       ret.list.push v.clone()
+    ret.type  = @type.clone()
     ret.line  = @line
     ret.pos   = @pos
     ret

--- a/src/ast_transform.coffee
+++ b/src/ast_transform.coffee
@@ -148,6 +148,25 @@ do ()=>
   walk = (root, ctx)->
     {walk} = ctx
     switch root.constructor.name
+      when "Fn_call"
+        if root.fn.constructor.name == "Var"
+          if root.fn.name == "require"
+            if root.arg_list.length == 2
+              root.fn.name = "require2"
+        ctx.next_gen root, ctx
+      
+      else
+        ctx.next_gen root, ctx
+    
+  
+  @require_distinguish = (root)->
+    walk root, {walk, next_gen: module.default_walk}
+# ###################################################################################################
+
+do ()=>
+  walk = (root, ctx)->
+    {walk} = ctx
+    switch root.constructor.name
       when "For3"
         ret = new ast.Scope
         ret.need_nest = false
@@ -669,6 +688,7 @@ do ()=>
 @ligo_pack = (root, opt={})->
   opt.router ?= true
   root = module.var_translate root
+  root = module.require_distinguish root
   root = module.for3_unpack root
   root = module.math_funcs_convert root
   root = module.ass_op_unpack root

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -1,3 +1,4 @@
+require "fy"
 ###
 TODO rename
   storage           -> storage_type_str
@@ -12,3 +13,15 @@ TODO rename
 @op_list = "opList" # var name
 @fix_underscore = "fx" # prefix var name
 @reserved = "reserved" # prefix var name
+
+@int_type_list = ["int"]
+for i in [8 .. 256] by 8
+  @int_type_list.push "int#{i}"
+
+@uint_type_list = ["uint"]
+for i in [8 .. 256] by 8
+  @uint_type_list.push "uint#{i}"
+
+@any_int_type_list = []
+@any_int_type_list.append @int_type_list
+@any_int_type_list.append @uint_type_list

--- a/src/solidity_to_ast4gen.coffee
+++ b/src/solidity_to_ast4gen.coffee
@@ -111,7 +111,7 @@ unpack_id_type = (root, ctx)->
     when "msg"
       new Type "struct" # fields would be replaced in type inference
     
-    when "bytes", "bytes32"
+    when "bytes"
       new Type "bytes"
 
     else

--- a/src/solidity_to_ast4gen.coffee
+++ b/src/solidity_to_ast4gen.coffee
@@ -89,19 +89,7 @@ unpack_id_type = (root, ctx)->
   switch root.typeString
     when "bool"
       new Type "bool"
-    
-    when "int8"
-      new Type "int8"
-    
-    when "uint8"
-      new Type "uint8"
-    
-    when "uint256"
-      new Type "uint"
-    
-    when "int256"
-      new Type "int"
-    
+        
     when "address"
       new Type "address"
     
@@ -111,12 +99,15 @@ unpack_id_type = (root, ctx)->
     when "msg"
       new Type "struct" # fields would be replaced in type inference
     
-    when "bytes"
-      new Type "bytes"
-
     else
-      # puts root # temp disable
-      throw new Error("unpack_id_type unknown typeString '#{root.typeString}'")
+      if root.typeString.match /^byte[s]?\d{0,2}$/
+        new Type "bytes"
+      else if root.typeString.match /^uint\d{0,3}$/
+        new Type "uint"
+      else if root.typeString.match /^int\d{0,3}$/
+        new Type "int"
+      else
+        throw new Error("unpack_id_type unknown typeString '#{root.typeString}'")
 
 walk_param = (root, ctx)->
   switch root.nodeType

--- a/src/solidity_to_ast4gen.coffee
+++ b/src/solidity_to_ast4gen.coffee
@@ -109,11 +109,11 @@ unpack_id_type = (root, ctx)->
       new Type "string"
     
     when "msg"
-      new Type "struct" # fields would be replaced in type inference
+      null # fields would be replaced in type inference
     
     when "bytes", "bytes32"
       new Type "bytes"
-
+    
     else
       # puts root # temp disable
       throw new Error("unpack_id_type unknown typeString '#{root.typeString}'")
@@ -479,7 +479,13 @@ walk = (root, ctx)->
       
       ret.type_i.nest_list = walk_param root.parameters, ctx
       unless ret.is_modifier
-        ret.type_o.nest_list = walk_param root.returnParameters, ctx
+        list = walk_param root.returnParameters, ctx
+        if list.length <= 1
+          ret.type_o.nest_list = list
+        else
+          tuple = new Type "tuple<>"
+          tuple.nest_list = list
+          ret.type_o.nest_list.push tuple
       
       scope_prepend_list = []
       if root.returnParameters

--- a/src/translate_ligo.coffee
+++ b/src/translate_ligo.coffee
@@ -110,14 +110,14 @@ walk = null
     # when config.storage
     #   config.storage
     else
-      if type.main.match /^byte[s]?\d{0,2}$/
+      if ctx.type_decl_hash[type.main]
+        type.main
+      else if type.main.match /^byte[s]?\d{0,2}$/
         "bytes"
       else if type.main.match /^uint\d{0,3}$/
         "nat"
       else if type.main.match /^int\d{0,3}$/
         "int"
-      else if ctx.type_decl_hash[type.main]
-        type.main
       else
         ### !pragma coverage-skip-block ###
         puts ctx.type_decl_hash

--- a/src/translate_ligo.coffee
+++ b/src/translate_ligo.coffee
@@ -79,22 +79,7 @@ walk = null
     # ###################################################################################################
     when "bool"
       "bool"
-    
-    when "uint"
-      "nat"
-    
-    when "int"
-      "int"
-    
-    when "int8"
-      "int"
-    
-    when "uint8"
-      "nat"
-    
-    when "bytes"
-      "bytes"
-    
+        
     when "string"
       "string"
     
@@ -125,7 +110,13 @@ walk = null
     # when config.storage
     #   config.storage
     else
-      if ctx.type_decl_hash[type.main]
+      if type.main.match /byte[s]?\d{0,2}/
+        "bytes"
+      else if type.main.match /int\d{0,3}/
+        "int"
+      else if type.main.match /nat\d{0,3}/
+        "nat"
+      else if ctx.type_decl_hash[type.main]
         type.main
       else
         ### !pragma coverage-skip-block ###

--- a/src/translate_ligo.coffee
+++ b/src/translate_ligo.coffee
@@ -110,11 +110,11 @@ walk = null
     # when config.storage
     #   config.storage
     else
-      if type.main.match /byte[s]?\d{0,2}/
+      if type.main.match /^byte[s]?\d{0,2}$/
         "bytes"
-      else if type.main.match /uint\d{0,3}/
+      else if type.main.match /^uint\d{0,3}$/
         "nat"
-      else if type.main.match /int\d{0,3}/
+      else if type.main.match /^int\d{0,3}$/
         "int"
       else if ctx.type_decl_hash[type.main]
         type.main

--- a/src/translate_ligo.coffee
+++ b/src/translate_ligo.coffee
@@ -406,7 +406,7 @@ walk = (root, ctx)->
       
       if root.fn.constructor.name == "Var"
         switch root.fn.name
-          when "require", "assert"
+          when "require", "require2", "assert"
             cond= arg_list[0]
             str = arg_list[1] or '"require fail"'
             return "if #{cond} then {skip} else failwith(#{str})"

--- a/src/translate_ligo.coffee
+++ b/src/translate_ligo.coffee
@@ -112,6 +112,12 @@ walk = null
       # "list(#{nest})"
       "map(nat, #{nest})"
     
+    when "tuple"
+      list = []
+      for v in type.nest_list
+        list.push translate_type v, ctx
+      "(#{list.join ' * '})"
+    
     when "map"
       key   = translate_type type.nest_list[0], ctx
       value = translate_type type.nest_list[1], ctx
@@ -158,96 +164,8 @@ walk = null
     else
       ### !pragma coverage-skip-block ###
       throw new Error("unknown solidity type '#{type}'")
-# ###################################################################################################
-#    translate_var_name
-# ###################################################################################################
-reserved_hash =
-  # https://gitlab.com/ligolang/ligo/blob/dev/src/passes/operators/operators.ml
-  "get_force"       : true
-  "get_chain_id"    : true
-  "transaction"     : true
-  "get_contract"    : true
-  "get_entrypoint"  : true
-  "size"            : true
-  "int"             : true
-  "abs"             : true
-  "is_nat"          : true
-  "amount"          : true
-  "balance"         : true
-  "now"             : true
-  "unit"            : true
-  "source"          : true
-  "sender"          : true
-  "failwith"        : true
-  "bitwise_or"      : true
-  "bitwise_and"     : true
-  "bitwise_xor"     : true
-  "string_concat"   : true
-  "string_slice"    : true
-  "crypto_check"    : true
-  "crypto_hash_key" : true
-  "bytes_concat"    : true
-  "bytes_slice"     : true
-  "bytes_pack"      : true
-  "bytes_unpack"    : true
-  "set_empty"       : true
-  "set_mem"         : true
-  "set_add"         : true
-  "set_remove"      : true
-  "set_iter"        : true
-  "set_fold"        : true
-  "list_iter"       : true
-  "list_fold"       : true
-  "list_map"        : true
-  "map_iter"        : true
-  "map_map"         : true
-  "map_fold"        : true
-  "map_remove"      : true
-  "map_update"      : true
-  "map_get"         : true
-  "map_mem"         : true
-  "sha_256"         : true
-  "sha_512"         : true
-  "blake2b"         : true
-  "cons"            : true
-  "EQ"              : true
-  "NEQ"             : true
-  "NEG"             : true
-  "ADD"             : true
-  "SUB"             : true
-  "TIMES"           : true
-  "DIV"             : true
-  "MOD"             : true
-  "NOT"             : true
-  "AND"             : true
-  "OR"              : true
-  "GT"              : true
-  "GE"              : true
-  "LT"              : true
-  "LE"              : true
-  "CONS"            : true
-  "address"         : true
-  "self_address"    : true
-  "implicit_account": true
-  "set_delegate"    : true
-  "to"              : true
-  "args"            : true
-  # note not reserved, but we don't want collide with types
-  
-  "map"             : true
 
-reserved_hash[config.contract_storage] = true
-reserved_hash[config.op_list] = true
-
-@translate_var_name = translate_var_name = (name)->
-  if reserved_hash[name]
-    "#{config.reserved}__#{name}"
-  else
-    if name[0] == "_"
-      "#{config.fix_underscore}_"+name
-    else
-      # first letter should be lowercase
-      name.substr(0,1).toLowerCase() + name.substr 1
+{translate_var_name} = require "./translate_var_name"
 # ###################################################################################################
 #    special id, field access
 # ###################################################################################################
@@ -764,14 +682,14 @@ walk = (root, ctx)->
         """
         #{translated_type}(#{args})
         """
-
+    
     when "Tuple"
       #TODO does this even work?
       arg_list = []
       for v in root.list
         arg_list.push walk v, ctx
       "(#{arg_list.join ', '})"
-
+    
     when "Array_init"
       arg_list = []
       for v in root.list

--- a/src/translate_ligo.coffee
+++ b/src/translate_ligo.coffee
@@ -112,10 +112,10 @@ walk = null
     else
       if type.main.match /byte[s]?\d{0,2}/
         "bytes"
+      else if type.main.match /uint\d{0,3}/
+        "nat"
       else if type.main.match /int\d{0,3}/
         "int"
-      else if type.main.match /nat\d{0,3}/
-        "nat"
       else if ctx.type_decl_hash[type.main]
         type.main
       else

--- a/src/translate_ligo_default_state.coffee
+++ b/src/translate_ligo_default_state.coffee
@@ -5,7 +5,6 @@ Type = require "type"
 {
   translate_type
   type2default_value
-  translate_var_name
 } = require "./translate_ligo"
 # ###################################################################################################
 

--- a/src/translate_ligo_default_state.coffee
+++ b/src/translate_ligo_default_state.coffee
@@ -12,14 +12,17 @@ class @Gen_context
   next_gen : null
   var_hash : {}
   contract_hash : {}
+  type_decl_hash: {}
   
   constructor:()->
     @var_hash = {}
-    @contract_hash = {}
+    @contract_hash  = {}
+    @type_decl_hash = {}
   
   mk_nest_contract : (name)->
     t = new module.Gen_context
     @contract_hash[name] = t.var_hash
+    obj_set t.type_decl_hash, @type_decl_hash
     t
 
 last_bracket_state = false
@@ -38,16 +41,21 @@ walk = (root, ctx)->
     
     when "Var_decl"
       ctx.var_hash[root.name] = {
-        type  : translate_type root.type
-        value : type2default_value root.type
+        type  : translate_type root.type, ctx
+        value : type2default_value root.type, ctx
       }
       "nothing"
     
     when "Class_decl"
       return if root.need_skip
+      ctx.type_decl_hash[root.name] = root
       if root.is_contract
         ctx = ctx.mk_nest_contract(root.name)
       walk root.scope, ctx
+    
+    when "Enum_decl"
+      ctx.type_decl_hash[root.name] = root
+      "nothing"
     
     else
       if ctx.next_gen?
@@ -67,8 +75,8 @@ walk = (root, ctx)->
     if 0 == h_count v
       type = new Type "uint"
       v[config.empty_state] = {
-        type  : translate_type type
-        value : type2default_value type
+        type  : translate_type type, ctx
+        value : type2default_value type, ctx
       }
   
   if !opt.convert_to_string

--- a/src/translate_var_name.coffee
+++ b/src/translate_var_name.coffee
@@ -1,0 +1,88 @@
+config = require "./config"
+reserved_hash =
+  # https://gitlab.com/ligolang/ligo/blob/dev/src/passes/operators/operators.ml
+  "get_force"       : true
+  "get_chain_id"    : true
+  "transaction"     : true
+  "get_contract"    : true
+  "get_entrypoint"  : true
+  "size"            : true
+  "int"             : true
+  "abs"             : true
+  "is_nat"          : true
+  "amount"          : true
+  "balance"         : true
+  "now"             : true
+  "unit"            : true
+  "source"          : true
+  "sender"          : true
+  "failwith"        : true
+  "bitwise_or"      : true
+  "bitwise_and"     : true
+  "bitwise_xor"     : true
+  "string_concat"   : true
+  "string_slice"    : true
+  "crypto_check"    : true
+  "crypto_hash_key" : true
+  "bytes_concat"    : true
+  "bytes_slice"     : true
+  "bytes_pack"      : true
+  "bytes_unpack"    : true
+  "set_empty"       : true
+  "set_mem"         : true
+  "set_add"         : true
+  "set_remove"      : true
+  "set_iter"        : true
+  "set_fold"        : true
+  "list_iter"       : true
+  "list_fold"       : true
+  "list_map"        : true
+  "map_iter"        : true
+  "map_map"         : true
+  "map_fold"        : true
+  "map_remove"      : true
+  "map_update"      : true
+  "map_get"         : true
+  "map_mem"         : true
+  "sha_256"         : true
+  "sha_512"         : true
+  "blake2b"         : true
+  "cons"            : true
+  "EQ"              : true
+  "NEQ"             : true
+  "NEG"             : true
+  "ADD"             : true
+  "SUB"             : true
+  "TIMES"           : true
+  "DIV"             : true
+  "MOD"             : true
+  "NOT"             : true
+  "AND"             : true
+  "OR"              : true
+  "GT"              : true
+  "GE"              : true
+  "LT"              : true
+  "LE"              : true
+  "CONS"            : true
+  "address"         : true
+  "self_address"    : true
+  "implicit_account": true
+  "set_delegate"    : true
+  "to"              : true
+  "args"            : true
+  # note not reserved, but we don't want collide with types
+  
+  "map"             : true
+
+reserved_hash[config.contract_storage] = true
+reserved_hash[config.op_list] = true
+
+@translate_var_name = (name)->
+  if reserved_hash[name]
+    "#{config.reserved}__#{name}"
+  else
+    if name[0] == "_"
+      "#{config.fix_underscore}_"+name
+    else
+      # first letter should be lowercase
+      name.substr(0,1).toLowerCase() + name.substr 1

--- a/src/type_inference.coffee
+++ b/src/type_inference.coffee
@@ -538,10 +538,8 @@ is_defined_number_type = (type)->
           switch root.op
             when "ASSIGN"
               if bruteforce_a and !bruteforce_b
-                change_count++ # TODO REMOVE
                 root.a.type = type_spread_left root.a.type, root.b.type
               else if !bruteforce_a and bruteforce_b
-                change_count++ # TODO REMOVE
                 root.b.type = type_spread_left root.b.type, root.a.type
             
             when "INDEX_ACCESS"
@@ -583,7 +581,6 @@ is_defined_number_type = (type)->
                   candidate_list.push pair
             
             if candidate_list.length == 1
-              change_count++ # TODO REMOVE
               [a_type, b_type] = candidate_list[0]
               root.a.type = type_spread_left root.a.type, new Type a_type
               root.b.type = type_spread_left root.b.type, new Type b_type
@@ -785,7 +782,7 @@ is_defined_number_type = (type)->
         perr root
         throw new Error "ti phase 2 unknown node '#{root.constructor.name}'"
   
-  change_count = 0  
+  change_count = 0
   for i in [0 ... 100] # prevent infinite
     walk ast_tree, new Ti_context
     # p "phase 2 ti change_count=#{change_count}" # DEBUG

--- a/test/translate_ligo.coffee
+++ b/test/translate_ligo.coffee
@@ -115,7 +115,7 @@ describe "translate ligo section", ()->
     type state is record
       reserved__empty_state : int;
     end;
-
+    
     function newKeyword (const opList : list(operation); const contractStorage : state) : (list(operation) * state) is
       block {
         const tokenCount : nat = 4n;
@@ -124,7 +124,7 @@ describe "translate ligo section", ()->
       } with (opList, contractStorage);
     """#"
     make_test text_i, text_o
-
+  
   it "return-tuple", ()->
     text_i = """
     pragma solidity ^0.5.11;
@@ -140,12 +140,11 @@ describe "translate ligo section", ()->
     type state is record
       reserved__empty_state : int;
     end;
-
+    
     function tupleRet (const reserved__unit : unit) : (nat * bool) is
       block {
         skip
-      } with ((7
-      , True));
+      } with ((7n, True));
     """#"
     make_test text_i, text_o
   

--- a/test/translate_ligo.coffee
+++ b/test/translate_ligo.coffee
@@ -141,7 +141,7 @@ describe "translate ligo section", ()->
       reserved__empty_state : int;
     end;
     
-    function tupleRet (const reserved__unit : unit) : (nat * bool) is
+    function tupleRet (const reserved__unit : unit) : ((nat * bool)) is
       block {
         skip
       } with ((7n, True));

--- a/test/translate_ligo_array.coffee
+++ b/test/translate_ligo_array.coffee
@@ -181,8 +181,8 @@ describe "translate ligo section", ()->
       block {
         const temp : map(nat, nat) = map
           0n -> abs(1);
-          1n -> 2;
-          2n -> 3;
+          1n -> 2n;
+          2n -> 3n;
         end;
       } with (opList, contractStorage);
     """

--- a/test/translate_ligo_var_type.coffee
+++ b/test/translate_ligo_var_type.coffee
@@ -16,8 +16,6 @@ describe "translate ligo section", ()->
       bool  public value_bool  ;
       int   public value_int   ;
       uint  public value_uint  ;
-      int8  public value_int8  ;
-      uint8 public value_uint8 ;
       address public value_address;
       string  public value_string;
       
@@ -29,10 +27,54 @@ describe "translate ligo section", ()->
       value_bool : bool;
       value_int : int;
       value_uint : nat;
-      value_int8 : int;
-      value_uint8 : nat;
       value_address : address;
       value_string : string;
+    end;
+    
+    function test (const opList : list(operation); const contractStorage : state) : (list(operation) * state) is
+      block {
+        skip
+      } with (opList, contractStorage);
+    
+    """
+    make_test text_i, text_o
+  it "extended types", ()->
+    text_i = """
+    pragma solidity ^0.5.11;
+
+    contract Basic_types {
+        int8 public value_int8;
+        int16 public value_int16;
+        int160 public value_int160;
+        int256 public value_int256;
+        uint8 public value_uint8;
+        uint16 public value_uint16;
+        uint160 public value_uint160;
+        uint256 public value_uint256;
+        byte public value_byte;
+        bytes public value_bytes;
+        bytes8 public value_bytes8;
+        bytes16 public value_bytes16;
+        bytes32 public value_bytes32;
+
+        function test() public {}
+    }
+    """
+    text_o = """
+    type state is record
+      value_int8 : int;
+      value_int16 : int;
+      value_int160 : int;
+      value_int256 : int;
+      value_uint8 : nat;
+      value_uint16 : nat;
+      value_uint160 : nat;
+      value_uint256 : nat;
+      value_byte : bytes;
+      value_bytes : bytes;
+      value_bytes8 : bytes;
+      value_bytes16 : bytes;
+      value_bytes32 : bytes;
     end;
     
     function test (const opList : list(operation); const contractStorage : state) : (list(operation) * state) is

--- a/test/util.coffee
+++ b/test/util.coffee
@@ -34,13 +34,13 @@ fs                  = require "fs"
       
       """
     
-    if fs.existsSync "ligo_tmp_log"
-      fs.unlinkSync "ligo_tmp_log"
+    if fs.existsSync "ligo_tmp_.log"
+      fs.unlinkSync "ligo_tmp.log"
     try
-      execSync "ligo compile-contract test.ligo main > ./ligo_tmp_log", {stdio: "inherit"}
+      execSync "ligo compile-contract test.ligo main > ./ligo_tmp.log", {stdio: "inherit"}
     catch err
       perr text_o_real
-      perr fs.readFileSync "./ligo_tmp_log", "utf-8"
+      perr fs.readFileSync "./ligo_tmp.log", "utf-8"
       throw err
       
   return


### PR DESCRIPTION
big type inference improve
 * type spread mechamism. Can tuple<number, uint> tuple<uint, null> interchange more defined parts
 * array.push fix arg type
 * revert fix arg type
 * require with 1 and 2 args now are different functions. Function overload (even for arg count) is not supported for now. So require2 is preprocessed with ast_transform
 * ast tuple added type (also in clone)
 * ast_transform for contract_storage conflict variable test. Now contract_storage must be translated before type inference (NOTE op_list is not, but should)
 * add all numeric types to type inference. Now you can make most operations with them.
 * removed msg struct type stub
 * tuple type translation
 * translate_var_name moved to separate file (trying keep translate_ligo size <10 kb. Now it is 20+ kb)
 * type inference fix for ast nodes
   * Tuple
   * Array_init
   * Fn_call
   * Var_decl
   * Ret_multi
 * all change_count++ moved to spread function
 * fix tests that their code is valid LIGO
 * MR #87 included and fixed
 * fix missing ctx in type translation functions;
 * add type_decl_hash to default state translation context
