### PR TITLE
Different fixes with types for real contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 node_modules
 coverage
 lib
-npm-debug.log
 solc-bin
 test.sol
 test.ligo
 test.pp.ligo
-ligo_tmp.log
+*.log
+report.sh

--- a/src/ast.coffee
+++ b/src/ast.coffee
@@ -164,7 +164,7 @@ class @Tuple
     ret = new module.Tuple
     for v in @list
       ret.list.push v.clone()
-    ret.type  = @type.clone()
+    ret.type  = @type.clone() if @type
     ret.line  = @line
     ret.pos   = @pos
     ret

--- a/src/ast.coffee
+++ b/src/ast.coffee
@@ -32,7 +32,15 @@ class @Class_decl
     for k,v of @_prepared_field2type
       ret._prepared_field2type[k] = v.clone()
     
-    ret.inheritance_list = deep_clone @inheritance_list
+    for v in @inheritance_list
+      arg_list = []
+      for arg in v.arg_list
+        arg_list.push arg.clone()
+      
+      ret.inheritance_list.push {
+        name : v.name
+        arg_list
+      }
     
     ret.line  = @line
     ret.pos   = @pos

--- a/src/ast_transform.coffee
+++ b/src/ast_transform.coffee
@@ -502,6 +502,9 @@ do ()=>
     {walk} = ctx
     switch root.constructor.name
       when "Class_decl"
+        is_constructor_name = (name)->
+          name == "constructor" or name == root.name
+        
         root = ctx.next_gen root, ctx
         ctx.class_hash[root.name] = root # store unmodified
         return root if !root.inheritance_list.length # for coverage purposes
@@ -538,7 +541,7 @@ do ()=>
           for v in look_list
             continue if v.constructor.name != "Fn_decl_multiret"
             v = v.clone()
-            if v.name == "constructor"
+            if is_constructor_name v.name
               v.name = "#{parent.name}_constructor"
               v.visibility = "internal"
               need_constuctor = v
@@ -556,14 +559,14 @@ do ()=>
           found_constructor = null
           for v in root.scope.list
             continue if v.constructor.name != "Fn_decl_multiret"
-            continue if v.name != "constructor"
+            continue if !is_constructor_name v.name
             found_constructor = v
             break
           
           # inject constructor call on top of my constructor (create my constructor if not exists)
           
           if !found_constructor
-            root.list.push found_constructor = new ast.Fn_decl_multiret
+            root.scope.list.unshift found_constructor = new ast.Fn_decl_multiret
             found_constructor.name = "constructor"
             found_constructor.type_i = new Type "function"
             found_constructor.type_o = new Type "function"
@@ -662,7 +665,7 @@ do ()=>
           
           # remove node
           ret = new ast.Comment
-          ret.text = "modifier #{root.name} removed"
+          ret.text = "modifier #{root.name} inlined"
           ret
         else
           return root if root.modifier_list.length == 0

--- a/src/ast_transform.coffee
+++ b/src/ast_transform.coffee
@@ -2,6 +2,7 @@ module = @
 Type  = require "type"
 config= require "./config"
 ast   = require "./ast"
+{translate_var_name} = require "./translate_var_name"
 
 # ###################################################################################################
 
@@ -107,7 +108,6 @@ do ()=>
   module.default_walk = out_walk
 
 # ###################################################################################################
-{translate_var_name} = require "./translate_var_name"
 # do not use full version. we need only replace contractStorage
 tweak_translate_var_name = (name)->
   if name == config.contract_storage
@@ -298,12 +298,12 @@ do ()=>
 
 do ()=>
   func2args_struct = (name)->
-    name = "#{config.fix_underscore}_#{name}" if name[0] == "_"
     name = name+"_args"
+    name = translate_var_name name, null
     name
   
   func2struct = (name)->
-    name = "#{config.fix_underscore}_#{name}" if name[0] == "_"
+    name = translate_var_name name, null
     name = name.capitalize()
     if name.length > 31
       new_name = name.substr 0, 31

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -25,3 +25,7 @@ for i in [8 .. 256] by 8
 @any_int_type_list = []
 @any_int_type_list.append @int_type_list
 @any_int_type_list.append @uint_type_list
+
+@bytes_type_list = []
+for i in [1 .. 32]
+  @bytes_type_list.push "bytes#{i}"

--- a/src/config.coffee
+++ b/src/config.coffee
@@ -26,6 +26,23 @@ for i in [8 .. 256] by 8
 @any_int_type_list.append @int_type_list
 @any_int_type_list.append @uint_type_list
 
-@bytes_type_list = []
+@bytes_type_list = ["bytes"]
 for i in [1 .. 32]
   @bytes_type_list.push "bytes#{i}"
+
+# hash versions for o(1) check
+@int_type_hash = {}
+for v in @int_type_list
+  @int_type_hash[v] = true
+
+@uint_type_hash = {}
+for v in @uint_type_list
+  @uint_type_hash[v] = true
+
+@any_int_type_hash = {}
+for v in @any_int_type_list
+  @any_int_type_hash[v] = true
+
+@bytes_type_hash = {}
+for v in @bytes_type_list
+  @bytes_type_hash[v] = true

--- a/src/solidity_to_ast4gen.coffee
+++ b/src/solidity_to_ast4gen.coffee
@@ -1,5 +1,6 @@
-Type = require "type"
-ast = require "./ast"
+config= require "./config"
+Type  = require "type"
+ast   = require "./ast"
 
 bin_op_map =
   "+"   : "ADD"
@@ -65,7 +66,15 @@ walk_type = (root, ctx)->
     return new Type root
   switch root.nodeType
     when "ElementaryTypeName"
-      new Type root.name
+      switch root.name
+        when "uint"
+          new Type "uint256"
+        
+        when "int"
+          new Type "int256"
+        
+        else
+          new Type root.name
     
     when "UserDefinedTypeName"
       new Type root.name
@@ -89,7 +98,16 @@ unpack_id_type = (root, ctx)->
   switch root.typeString
     when "bool"
       new Type "bool"
-        
+    
+    when "uint"
+      new Type "uint256"
+    
+    when "int"
+      new Type "int256"
+    
+    when "byte", "bytes"
+      new Type "bytes1"
+    
     when "address"
       new Type "address"
     
@@ -106,12 +124,12 @@ unpack_id_type = (root, ctx)->
       null # fields would be replaced in type inference
     
     else
-      if root.typeString.match /^(byte|bytes\d{0,2})$/
-        new Type "bytes"
-      else if root.typeString.match /^uint\d{0,3}$/
-        new Type "uint"
-      else if root.typeString.match /^int\d{0,3}$/
-        new Type "int"
+      if root.typeString.match /^bytes\d{1,2}$/
+        new Type root.typeString
+      else if config.uint_type_list.has root.typeString
+        new Type root.typeString
+      else if config.int_type_list.has root.typeString
+        new Type root.typeString
       else
         throw new Error("unpack_id_type unknown typeString '#{root.typeString}'")
 

--- a/src/solidity_to_ast4gen.coffee
+++ b/src/solidity_to_ast4gen.coffee
@@ -167,11 +167,14 @@ walk = (root, ctx)->
       
       ret.inheritance_list = []
       for v in root.baseContracts
+        arg_list = []
         if v.arguments
-          throw new Error "arguments not supported for inheritance for now"
+          for arg in v.arguments
+            arg_list.push walk arg, ctx
+        
         ret.inheritance_list.push {
           name : v.baseName.name
-          # TODO arg_list
+          arg_list
         }
       ret.name = root.name
       for node in root.nodes

--- a/src/solidity_to_ast4gen.coffee
+++ b/src/solidity_to_ast4gen.coffee
@@ -355,16 +355,21 @@ walk = (root, ctx)->
       ret
     
     when "TupleExpression"
-      if root.isInlineArray 
+      if root.isInlineArray
         ret = new ast.Array_init
       else
         ret = new ast.Tuple
-
+      
       for v in root.components
         if v?
           ret.list.push walk v, ctx
         else
           ret.list.push null
+      
+      if ret.constructor.name == "Tuple"
+        if ret.list.length == 1
+          ret = ret.list[0]
+      
       ret
     
     when "NewExpression"

--- a/src/solidity_to_ast4gen.coffee
+++ b/src/solidity_to_ast4gen.coffee
@@ -268,7 +268,67 @@ walk = (root, ctx)->
       ret = new ast.Const
       ret.type  = new Type root.kind
       ret.val   = root.value
-      ret
+      switch root.subdenomination
+        when "seconds"
+          ret
+        when "minutes"
+          mult = new ast.Const
+          mult.type  = new Type root.kind
+          mult.val = 60
+          exp = new ast.Bin_op
+          exp.op = bin_op_map["*"]
+          exp.a = ret
+          exp.b = mult
+          exp
+        when "hours"
+          mult = new ast.Const
+          mult.type  = new Type root.kind
+          mult.val = 3600
+          exp = new ast.Bin_op
+          exp.op = bin_op_map["*"]
+          exp.a = ret
+          exp.b = mult
+          exp
+        when "days"
+          mult = new ast.Const
+          mult.type  = new Type root.kind
+          mult.val = 86400
+          exp = new ast.Bin_op
+          exp.op = bin_op_map["*"]
+          exp.a = ret
+          exp.b = mult
+          exp
+        when "weeks"
+          mult = new ast.Const
+          mult.type  = new Type root.kind
+          mult.val = 604800
+          exp = new ast.Bin_op
+          exp.op = bin_op_map["*"]
+          exp.a = ret
+          exp.b = mult
+          exp
+        when "szabo"
+          ret
+        when "finney"
+          mult = new ast.Const
+          mult.type  = new Type root.kind
+          mult.val = 1000
+          exp = new ast.Bin_op
+          exp.op = bin_op_map["*"]
+          exp.a = ret
+          exp.b = mult
+          exp
+        when "ether"
+          mult = new ast.Const
+          mult.type  = new Type root.kind
+          mult.val = 1000000
+          exp = new ast.Bin_op
+          exp.op = bin_op_map["*"]
+          exp.a = ret
+          exp.b = mult
+          exp
+        else
+          ret
     
     when "VariableDeclaration"
       ret = new ast.Var_decl

--- a/src/translate_ligo.coffee
+++ b/src/translate_ligo.coffee
@@ -420,6 +420,14 @@ walk = (root, ctx)->
           when "revert"
             str = arg_list[0] or '"revert"'
             return "failwith(#{str})"
+
+          when "sha256", "sha3", "keccak256"
+            msg = arg_list[0]
+            return "sha_256(#{msg})"
+
+          when "ripemd160"
+            msg = arg_list[0]
+            return "blake2b(#{msg})"
           
           else
             name = root.fn.name

--- a/src/translate_ligo.coffee
+++ b/src/translate_ligo.coffee
@@ -19,6 +19,9 @@ walk = null
   LT  : "<"
   GTE : ">="
   LTE : "<="
+  SHR : "LIGO_IMPLEMENT_ME_PLEASE_SHR"
+  SHL : "LIGO_IMPLEMENT_ME_PLEASE_SHL"
+  POW : "LIGO_IMPLEMENT_ME_PLEASE_POW"
   
   BOOL_AND: "and"
   BOOL_OR : "or"
@@ -55,6 +58,10 @@ walk = null
     else
       "not (#{a})"
   BOOL_NOT: (a)->"not (#{a})"
+  RET_INC : (a, ctx)->
+    perr "RET_INC can have not fully correct implementation"
+    ctx.sink_list.push "#{a} := #{a} + 1"
+    "(#{a} - 1)"
   
   DELETE : (a, ctx, ast)->
     if ast.a.constructor.name != "Bin_op"
@@ -146,7 +153,7 @@ walk = null
     when "built_in_op_list"
       "(nil: list(operation))"
     
-    when "map"
+    when "map", "array"
       "map end : #{translate_type type, ctx}"
     
     when "string"

--- a/src/translate_ligo.coffee
+++ b/src/translate_ligo.coffee
@@ -1,6 +1,7 @@
 module = @
 require "fy/codegen"
 config = require "./config"
+module.warning_counter = 0
 # ###################################################################################################
 #    *_op
 # ###################################################################################################
@@ -311,6 +312,11 @@ walk = (root, ctx)->
               "False"
             else
               throw new Error "can't translate bool constant '#{root.val}'"
+        
+        when "number"
+          perr "WARNING number constant passed to translation stage. That's type inference mistake"
+          module.warning_counter++
+          root.val
         
         when "string"
           JSON.stringify root.val

--- a/src/translate_ligo.coffee
+++ b/src/translate_ligo.coffee
@@ -352,6 +352,14 @@ walk = (root, ctx)->
             else
               throw new Error "unknown array field #{root.name}"
         
+        when "bytes"
+          switch root.name
+            when "length"
+              return "size(#{t})"
+            
+            else
+              throw new Error "unknown array field #{root.name}"
+        
       # else
       if t == "" # this case
         return translate_var_name root.name, ctx

--- a/src/translate_ligo.coffee
+++ b/src/translate_ligo.coffee
@@ -19,8 +19,6 @@ walk = null
   LT  : "<"
   GTE : ">="
   LTE : "<="
-  SHR : "LIGO_IMPLEMENT_ME_PLEASE_SHR"
-  SHL : "LIGO_IMPLEMENT_ME_PLEASE_SHL"
   POW : "LIGO_IMPLEMENT_ME_PLEASE_POW"
   
   BOOL_AND: "and"
@@ -31,6 +29,8 @@ walk = null
   BIT_AND : (a, b)-> "bitwise_and(#{a}, #{b})"
   BIT_OR  : (a, b)-> "bitwise_or(#{a}, #{b})"
   BIT_XOR : (a, b)-> "bitwise_xor(#{a}, #{b})"
+  SHR : (a, b)-> "bitwise_lsr(#{a}, #{b})"
+  SHL : (a, b)-> "bitwise_lsl(#{a}, #{b})"
   
   # disabled until requested
   INDEX_ACCESS : (a, b, ctx, ast)->

--- a/src/translate_ligo.coffee
+++ b/src/translate_ligo.coffee
@@ -19,8 +19,6 @@ walk = null
   LT  : "<"
   GTE : ">="
   LTE : "<="
-  SHR : "LIGO_IMPLEMENT_ME_PLEASE_SHR"
-  SHL : "LIGO_IMPLEMENT_ME_PLEASE_SHL"
   POW : "LIGO_IMPLEMENT_ME_PLEASE_POW"
   
   BOOL_AND: "and"
@@ -30,7 +28,8 @@ walk = null
   ASSIGN  : (a, b)-> "#{a} := #{b}"
   BIT_AND : (a, b)-> "bitwise_and(#{a}, #{b})"
   BIT_OR  : (a, b)-> "bitwise_or(#{a}, #{b})"
-  BIT_XOR : (a, b)-> "bitwise_xor(#{a}, #{b})"
+  SHR : (a, b)-> "bitwise_lsr(#{a}, #{b})"
+  SHL : (a, b)-> "bitwise_lsl(#{a}, #{b})"
   
   # disabled until requested
   INDEX_ACCESS : (a, b, ctx, ast)->

--- a/src/translate_ligo.coffee
+++ b/src/translate_ligo.coffee
@@ -29,8 +29,8 @@ walk = null
   BIT_AND : (a, b)-> "bitwise_and(#{a}, #{b})"
   BIT_OR  : (a, b)-> "bitwise_or(#{a}, #{b})"
   BIT_XOR : (a, b)-> "bitwise_xor(#{a}, #{b})"
-  SHR : (a, b)-> "bitwise_lsr(#{a}, #{b})"
-  SHL : (a, b)-> "bitwise_lsl(#{a}, #{b})"
+  SHR     : (a, b)-> "bitwise_lsr(#{a}, #{b})"
+  SHL     : (a, b)-> "bitwise_lsl(#{a}, #{b})"
   
   # disabled until requested
   INDEX_ACCESS : (a, b, ctx, ast)->

--- a/src/translate_var_name.coffee
+++ b/src/translate_var_name.coffee
@@ -73,12 +73,16 @@ reserved_hash =
   # note not reserved, but we don't want collide with types
   
   "map"             : true
+  
+  # WTF
+  "some"            : true
+  
 
 reserved_hash[config.contract_storage] = true
 reserved_hash[config.op_list] = true
 
-@translate_var_name = (name)->
-  if reserved_hash[name]
+@translate_var_name = (name, ctx)->
+  if reserved_hash[name] and name != "constructor"
     "#{config.reserved}__#{name}"
   else
     if name[0] == "_"

--- a/src/type_inference.coffee
+++ b/src/type_inference.coffee
@@ -65,6 +65,7 @@ address_field_hash =
   ]
   BIT_NOT : []
   MINUS   : []
+  RET_INC : []
 }
 
 # ###################################################################################################
@@ -76,6 +77,9 @@ do ()=>
   
   for type in config.int_type_list
     @un_op_ret_type_hash_list.MINUS.push [type, type]
+  
+  for type in config.any_int_type_list
+    @un_op_ret_type_hash_list.RET_INC.push [type, type]
     
   for v in "ADD SUB MUL POW".split  /\s+/g
     @bin_op_ret_type_hash_list[v] = list = []
@@ -93,7 +97,7 @@ do ()=>
       list.push [type, type, "bool"]
   
   # special
-  for v in "SHL SHR".split  /\s+/g
+  for v in "SHL SHR POW".split  /\s+/g
     @bin_op_ret_type_hash_list[v] = list = []
     for type_main in config.uint_type_list
       for type_index in config.uint_type_list

--- a/src/type_inference.coffee
+++ b/src/type_inference.coffee
@@ -9,7 +9,7 @@ module = @
     msg : (()->
       ret = new Type "struct"
       ret.field_hash.sender = new Type "address"
-      ret.field_hash.value  = new Type "uint"
+      ret.field_hash.value  = new Type "uint256"
       ret.field_hash.data   = new Type "bytes"
       ret
     )()
@@ -20,10 +20,10 @@ module = @
     )()
     block : (()->
       ret = new Type "struct"
-      ret.field_hash["timestamp"] = new Type "uint"
+      ret.field_hash["timestamp"] = new Type "uint256"
       ret
     )()
-    now     : new Type "uint"
+    now     : new Type "uint256"
     require : new Type "function2_pure<function<bool>,function<>>"
     require2: new Type "function2_pure<function<bool, string>,function<>>"
     assert  : new Type "function2_pure<function<bool>,function<>>"
@@ -31,15 +31,15 @@ module = @
   }
 
 array_field_hash =
-  "length": new Type "uint"
+  "length": new Type "uint256"
   "push"  : (type)->
     ret = new Type "function2_pure<function<>,function<>>"
     ret.nest_list[0].nest_list.push type.nest_list[0]
     ret
 
 address_field_hash =
-  "send"    : new Type "function2_pure<function2<uint>,function2<bool>>"
-  "transfer": new Type "function2_pure<function2<uint>,function2<>>" # throws on false
+  "send"    : new Type "function2_pure<function2<uint256>,function2<bool>>"
+  "transfer": new Type "function2_pure<function2<uint256>,function2<>>" # throws on false
 
 @default_type_hash_gen = ()->
   ret = {
@@ -557,7 +557,7 @@ is_defined_number_type = (type)->
               if !bruteforce_a and bruteforce_b
                 switch root.a.type?.main
                   when "array"
-                    root.b.type = type_spread_left root.b.type, new Type "uint"
+                    root.b.type = type_spread_left root.b.type, new Type "uint256"
                   
                   when "map"
                     root.b.type = type_spread_left root.b.type, root.a.type.nest_list[0]

--- a/src/type_inference.coffee
+++ b/src/type_inference.coffee
@@ -38,6 +38,9 @@ array_field_hash =
     ret.nest_list[0].nest_list.push type.nest_list[0]
     ret
 
+bytes_field_hash =
+  "length": new Type "uint256"
+
 address_field_hash =
   "send"    : new Type "function2_pure<function2<uint256>,function2<bool>>"
   "transfer": new Type "function2_pure<function2<uint256>,function2<>>" # throws on false
@@ -45,12 +48,16 @@ address_field_hash =
 @default_type_hash_gen = ()->
   ret = {
     bool    : true
+    bytes   : true
     array   : true
     string  : true
     address : true
   }
   
   for type in config.any_int_type_list
+    ret[type] = true
+  
+  for type in config.bytes_type_list
     ret[type] = true
   
   ret
@@ -359,6 +366,9 @@ is_defined_number_type = (type)->
         switch root_type.main
           when "array"
             field_hash = array_field_hash
+          
+          when "bytes"
+            field_hash = bytes_field_hash
           
           when "address"
             field_hash = address_field_hash
@@ -688,6 +698,9 @@ is_defined_number_type = (type)->
         switch root_type.main
           when "array"
             field_hash = array_field_hash
+          
+          when "bytes"
+            field_hash = bytes_field_hash
           
           when "address"
             field_hash = address_field_hash

--- a/src/type_inference.coffee
+++ b/src/type_inference.coffee
@@ -29,6 +29,10 @@ module = @
     require2: new Type "function2_pure<function<bool, string>,function<>>"
     assert  : new Type "function2_pure<function<bool>,function<>>"
     revert  : new Type "function2_pure<function<string>,function<>>"
+    sha256  : new Type "function2_pure<function<bytes>,function<bytes32>>"
+    sha3  : new Type "function2_pure<function<bytes>,function<bytes32>>"
+    keccak256  : new Type "function2_pure<function<bytes>,function<bytes32>>"
+    ripemd160  : new Type "function2_pure<function<bytes>,function<bytes20>>"
   }
 
 array_field_hash =

--- a/src/type_safe.coffee
+++ b/src/type_safe.coffee
@@ -1,0 +1,55 @@
+Type = require "type"
+
+Type.prototype.clone = ()->
+  ret = new Type
+  ret.main = @main
+  for v in @nest_list
+    if !v?
+      ret.nest_list.push v
+    else
+      ret.nest_list.push v.clone()
+  for k,v of @field_hash
+    if !v?
+      ret.field_hash[k] = v
+    else
+      ret.field_hash[k] = v.clone()
+  ret
+
+null_str = "\x1E"
+
+Type.prototype.toString = ()->
+  ret = @main
+  if @nest_list.length
+    jl = []
+    for v in @nest_list
+      if !v?
+        jl.push null_str
+      else
+        jl.push v.toString()
+    ret += "<#{jl.join ', '}>"
+  
+  jl = []
+  for k,v of @field_hash
+    if !v?
+      jl.push "#{k}: #{null_str}"
+    else
+      jl.push "#{k}: #{v.toString()}"
+  if jl.length
+    ret += "{#{jl.join ', '}}"
+  
+  ret
+
+Type.prototype.cmp = (t)->
+  return false if @main != t.main
+  return false if @nest_list.length != t.nest_list.length
+  for v,k in @nest_list
+    continue if t.nest_list[k] == v
+    return false if !t.nest_list[k].cmp v
+  for k,v of @field_hash
+    continue if t.field_hash[k] == v
+    return false if !tv = t.field_hash[k]
+    return false if !tv.cmp v
+  for k,v of t.field_hash
+    return false if !tv = @field_hash[k]
+    # return false if !tv.cmp v
+  true

--- a/test/translate_ligo.coffee
+++ b/test/translate_ligo.coffee
@@ -98,6 +98,57 @@ describe "translate ligo section", ()->
       } with (opList, contractStorage);
     """#"
     make_test text_i, text_o
+  it "constants", ()->
+      text_i = """
+      pragma solidity ^0.5.11;
+      contract Consttypes {
+          uint256 public timesSeconds;
+          uint256 public timeMinutes;
+          uint256 public timeHours;
+          uint256 public timeWeeks;
+          uint256 public timeDays;
+          uint256 public amountSzabo;
+          uint256 public amountFinney;
+          uint256 public amountEther;
+
+          function test() public {
+              timesSeconds = 100 seconds;
+              timeMinutes = 12 minutes;
+              timeHours = 3 weeks;
+              timeWeeks = 11 hours;
+              timeDays = 1 days;
+              amountSzabo = 12 szabo;
+              amountFinney = 3 finney;
+              amountEther = 11 ether;
+          }
+      }
+      """#"
+      text_o = """
+      type state is record
+        timesSeconds : nat;
+        timeMinutes : nat;
+        timeHours : nat;
+        timeWeeks : nat;
+        timeDays : nat;
+        amountSzabo : nat;
+        amountFinney : nat;
+        amountEther : nat;
+      end;
+
+      function test (const opList : list(operation); const contractStorage : state) : (list(operation) * state) is
+        block {
+          contractStorage.timesSeconds := 100n;
+          contractStorage.timeMinutes := (12n * 60n);
+          contractStorage.timeHours := (3n * 604800n);
+          contractStorage.timeWeeks := (11n * 3600n);
+          contractStorage.timeDays := (1n * 86400n);
+          contractStorage.amountSzabo := 12n;
+          contractStorage.amountFinney := (3n * 1000n);
+          contractStorage.amountEther := (11n * 1000000n);
+        } with (opList, contractStorage);
+
+      """#"
+      make_test text_i, text_o
 
   it "new-keyword", ()->
     text_i = """

--- a/test/translate_ligo_fn.coffee
+++ b/test/translate_ligo_fn.coffee
@@ -273,6 +273,34 @@ describe "translate ligo section", ()->
     """#"
     make_test text_i, text_o
   
+  it "crypto fn", ()->
+    text_i = """
+    pragma solidity ^0.4.16;
+
+    contract UnOpTest {
+        function test2(bytes b0) internal {
+            bytes32 h0 = sha256(b0);
+            bytes20 h1 = ripemd160(b0);
+            bytes32 h2 = sha3(b0);
+            bytes32 h3 = keccak256(b0);
+        }
+    }
+    """#"
+    text_o = """
+    type state is record
+      reserved__empty_state : int;
+    end;
+
+    function test2 (const opList : list(operation); const contractStorage : state; const b0 : bytes) : (list(operation) * state) is
+      block {
+        const h0 : bytes = sha_256(b0);
+        const h1 : bytes = blake2b(b0);
+        const h2 : bytes = sha_256(b0);
+        const h3 : bytes = sha_256(b0);
+      } with (opList, contractStorage);
+    """#"
+    make_test text_i, text_o
+
   it "require 0.4", ()->
     text_i = """
     pragma solidity >=0.4.21;

--- a/test/translate_ligo_inheritance.coffee
+++ b/test/translate_ligo_inheritance.coffee
@@ -1,0 +1,91 @@
+config = require "../src/config"
+{
+  translate_ligo_make_test : make_test
+} = require("./util")
+
+describe "translate ligo section", ()->
+  @timeout 10000
+  it "basic", ()->
+    text_i = """
+    pragma solidity ^0.4.26;
+    
+    contract Ownable {
+      function one(uint i) {
+        i = 1;
+      }
+    }
+    
+    contract Sample is Ownable {
+      function Sample() {
+        
+      }
+      
+      function some(uint i) {
+      
+      }
+    }
+    """
+    text_o = """
+    type state is record
+      reserved__empty_state : int;
+    end;
+    
+    function one (const opList : list(operation); const contractStorage : state; const i : nat) : (list(operation) * state) is
+      block {
+        i := 1n;
+      } with (opList, contractStorage);
+    
+    function sample (const opList : list(operation); const contractStorage : state) : (list(operation) * state) is
+      block {
+        skip
+      } with (opList, contractStorage);
+    
+    function reserved__some (const opList : list(operation); const contractStorage : state; const i : nat) : (list(operation) * state) is
+      block {
+        skip
+      } with (opList, contractStorage);
+    """
+    make_test text_i, text_o
+  
+  it "With args THIS TEST IS WRONG. NO CONSTRUCTOR BODY", ()->
+    text_i = """
+    pragma solidity ^0.4.26;
+    
+    contract Ownable {
+      function Ownable(uint i) {
+        i = 1;
+      }
+    }
+    
+    contract Sample is Ownable(0) {
+      function Sample() {
+        
+      }
+      
+      function some(uint i) {
+      
+      }
+    }
+    """
+    text_o = """
+    type state is record
+      reserved__empty_state : int;
+    end;
+    
+    function ownable (const opList : list(operation); const contractStorage : state; const i : nat) : (list(operation) * state) is
+      block {
+        i := 1n;
+      } with (opList, contractStorage);
+    
+    function sample (const opList : list(operation); const contractStorage : state) : (list(operation) * state) is
+      block {
+        skip
+      } with (opList, contractStorage);
+    
+    function reserved__some (const opList : list(operation); const contractStorage : state; const i : nat) : (list(operation) * state) is
+      block {
+        skip
+      } with (opList, contractStorage);
+    """
+    make_test text_i, text_o
+  

--- a/test/translate_ligo_modifier.coffee
+++ b/test/translate_ligo_modifier.coffee
@@ -32,7 +32,7 @@ describe "translate ligo section", ()->
       a : bool;
     end;
     
-    (* modifier lock removed *)
+    (* modifier lock inlined *)
     
     function test (const opList : list(operation); const contractStorage : state) : (list(operation) * state) is
       block {
@@ -70,7 +70,7 @@ describe "translate ligo section", ()->
       val : bool;
     end;
     
-    (* modifier greaterThan removed *)
+    (* modifier greaterThan inlined *)
     
     function test (const opList : list(operation); const contractStorage : state; const a : nat) : (list(operation) * state) is
       block {

--- a/test/translate_ligo_ops.coffee
+++ b/test/translate_ligo_ops.coffee
@@ -8,129 +8,178 @@ describe "translate ligo section", ()->
   # ###################################################################################################
   #    expr
   # ###################################################################################################
-  it "uint un_ops", ()->
-    text_i = """
-    pragma solidity ^0.5.11;
-    
-    contract Expr {
-      uint public value;
-      
-      function expr() public returns (uint) {
-        uint a = 0;
-        uint c = 0;
-        c = ~a;
-        c = uint(~0);
-        return c;
-      }
-    }
-    """#"
-    text_o = """
-      type state is record
-        value : nat;
-      end;
-      
-      function expr (const opList : list(operation); const contractStorage : state) : (list(operation) * state * nat) is
-        block {
-          const a : nat = 0n;
-          const c : nat = 0n;
-          c := abs(not (a));
-          c := abs(not (0));
-        } with (opList, contractStorage, c);
-    """
-    make_test text_i, text_o
+  describe "uintX un_ops", ()->
+    for type in config.uint_type_list
+      it "#{type} un_ops", ()->
+        text_i = """
+        pragma solidity ^0.5.11;
+        
+        contract Expr {
+          #{type} public value;
+          
+          function expr() public returns (#{type}) {
+            #{type} a = 0;
+            #{type} c = 0;
+            c = ~a;
+            c = #{type}(~0);
+            return c;
+          }
+        }
+        """#"
+        text_o = """
+          type state is record
+            value : nat;
+          end;
+          
+          function expr (const opList : list(operation); const contractStorage : state) : (list(operation) * state * nat) is
+            block {
+              const a : nat = 0n;
+              const c : nat = 0n;
+              c := abs(not (a));
+              c := abs(not (0));
+            } with (opList, contractStorage, c);
+        """
+        make_test text_i, text_o
   
-  it "uint bin_ops", ()->
-    text_i = """
-    pragma solidity ^0.5.11;
+  describe "uintX bin_ops", ()->
+    for type in config.uint_type_list
+      it "#{type} bin_ops", ()->
+        text_i = """
+        pragma solidity ^0.5.11;
+        
+        contract Expr {
+          #{type} public value;
+          
+          function expr() public returns (#{type}) {
+            #{type} a = 0;
+            #{type} b = 0;
+            #{type} c = 0;
+            c = a + b;
+            c = a - b;
+            c = a * b;
+            c = a / b;
+            c = a % b;
+            c = a & b;
+            c = a | b;
+            c = a ^ b;
+            c += b;
+            c -= b;
+            c *= b;
+            c /= b;
+            c %= b;
+            c &= b;
+            c |= b;
+            c ^= b;
+            return c;
+          }
+        }
+        """#"
+        text_o = """
+          type state is record
+            value : nat;
+          end;
+          
+          function expr (const opList : list(operation); const contractStorage : state) : (list(operation) * state * nat) is
+            block {
+              const a : nat = 0n;
+              const b : nat = 0n;
+              const c : nat = 0n;
+              c := (a + b);
+              c := abs(a - b);
+              c := (a * b);
+              c := (a / b);
+              c := (a mod b);
+              c := bitwise_and(a, b);
+              c := bitwise_or(a, b);
+              c := bitwise_xor(a, b);
+              c := (c + b);
+              c := abs(c - b);
+              c := (c * b);
+              c := (c / b);
+              c := (c mod b);
+              c := bitwise_and(c, b);
+              c := bitwise_or(c, b);
+              c := bitwise_xor(c, b);
+            } with (opList, contractStorage, c);
+          
+        """
+        make_test text_i, text_o
     
-    contract Expr {
-      uint public value;
-      
-      function expr() public returns (uint) {
-        uint a = 0;
-        uint b = 0;
-        uint c = 0;
-        c = a + b;
-        c = a - b;
-        c = a * b;
-        c = a / b;
-        c = a % b;
-        c = a & b;
-        c = a | b;
-        c = a ^ b;
-        c += b;
-        c -= b;
-        c *= b;
-        c /= b;
-        c %= b;
-        c &= b;
-        c |= b;
-        c ^= b;
-        return c;
-      }
-    }
-    """#"
-    text_o = """
-      type state is record
-        value : nat;
-      end;
-      
-      function expr (const opList : list(operation); const contractStorage : state) : (list(operation) * state * nat) is
-        block {
-          const a : nat = 0n;
-          const b : nat = 0n;
-          const c : nat = 0n;
-          c := (a + b);
-          c := abs(a - b);
-          c := (a * b);
-          c := (a / b);
-          c := (a mod b);
-          c := bitwise_and(a, b);
-          c := bitwise_or(a, b);
-          c := bitwise_xor(a, b);
-          c := (c + b);
-          c := abs(c - b);
-          c := (c * b);
-          c := (c / b);
-          c := (c mod b);
-          c := bitwise_and(c, b);
-          c := bitwise_or(c, b);
-          c := bitwise_xor(c, b);
-        } with (opList, contractStorage, c);
-      
-    """
-    make_test text_i, text_o
+    for type in config.uint_type_list
+      it "cmp #{type}", ()->
+        text_i = """
+        pragma solidity ^0.5.11;
+        
+        contract Expr {
+          #{type} public value;
+          
+          function expr() public returns (#{type}) {
+            #{type} a = 0;
+            #{type} b = 0;
+            bool c;
+            c = a <  b;
+            c = a <= b;
+            c = a >  b;
+            c = a >= b;
+            c = a == b;
+            c = a != b;
+            return 0;
+          }
+        }
+        """#"
+        text_o = """
+          type state is record
+            value : nat;
+          end;
+          
+          function expr (const opList : list(operation); const contractStorage : state) : (list(operation) * state * nat) is
+            block {
+              const a : nat = 0n;
+              const b : nat = 0n;
+              const c : bool = False;
+              c := (a < b);
+              c := (a <= b);
+              c := (a > b);
+              c := (a >= b);
+              c := (a = b);
+              c := (a =/= b);
+            } with (opList, contractStorage, 0n);
+          
+        """
+        make_test text_i, text_o
   
-  it "int un_ops", ()->
-    text_i = """
-    pragma solidity ^0.5.11;
-    
-    contract Expr {
-      uint public value;
-      
-      function expr() public returns (int) {
-        int a = 0;
-        int c = 0;
-        c = ~a;
-        c = int(~0);
-        return c;
-      }
-    }
-    """#"
-    text_o = """
-      type state is record
-        value : nat;
-      end;
-      
-      function expr (const opList : list(operation); const contractStorage : state) : (list(operation) * state * int) is
-        block {
-          const a : int = 0;
-          const c : int = 0;
-          c := not (a);
-          c := int(abs(not (0)));
-        } with (opList, contractStorage, c);
-    """
-    make_test text_i, text_o
+  describe "intX un_ops", ()->
+    for type in config.int_type_list
+      it "#{type} un_ops", ()->
+        text_i = """
+        pragma solidity ^0.5.11;
+        
+        contract Expr {
+          uint public value;
+          
+          function expr() public returns (#{type}) {
+            #{type} a = 0;
+            #{type} c = 0;
+            c = ~a;
+            c = #{type}(~0);
+            return c;
+          }
+        }
+        """#"
+        text_o = """
+          type state is record
+            value : nat;
+          end;
+          
+          function expr (const opList : list(operation); const contractStorage : state) : (list(operation) * state * int) is
+            block {
+              const a : int = 0;
+              const c : int = 0;
+              c := not (a);
+              c := int(abs(not (0)));
+            } with (opList, contractStorage, c);
+        """
+        make_test text_i, text_o
   # TODO support mod & | ^ LATER
   # it "int bin_ops", ()->
   #   text_i = """
@@ -196,138 +245,99 @@ describe "translate ligo section", ()->
   #   """
   #   make_test text_i, text_o
   # 
-  it "int bin_ops", ()->
-    text_i = """
-    pragma solidity ^0.5.11;
+  describe "intX bin_ops", ()->
+    for type in config.int_type_list
+      it "#{type} bin_ops", ()->
+        text_i = """
+        pragma solidity ^0.5.11;
+        
+        contract Expr {
+          #{type} public value;
+          
+          function expr() public returns (#{type}) {
+            #{type} a = 0;
+            #{type} b = 0;
+            #{type} c = 0;
+            c = -c;
+            c = a + b;
+            c = a - b;
+            c = a * b;
+            c = a / b;
+            c += b;
+            c -= b;
+            c *= b;
+            c /= b;
+            return c;
+          }
+        }
+        """#"
+        text_o = """
+          type state is record
+            value : int;
+          end;
+          
+          function expr (const opList : list(operation); const contractStorage : state) : (list(operation) * state * int) is
+            block {
+              const a : int = 0;
+              const b : int = 0;
+              const c : int = 0;
+              c := -(c);
+              c := (a + b);
+              c := (a - b);
+              c := (a * b);
+              c := (a / b);
+              c := (c + b);
+              c := (c - b);
+              c := (c * b);
+              c := (c / b);
+            } with (opList, contractStorage, c);
+          
+        """
+        make_test text_i, text_o
     
-    contract Expr {
-      int public value;
+    for type in config.int_type_list
+      it "cmp #{type}", ()->
+        text_i = """
+        pragma solidity ^0.5.11;
+        
+        contract Expr {
+          uint public value;
+          
+          function expr() public returns (uint) {
+            #{type} a = 0;
+            #{type} b = 0;
+            bool c;
+            c = a <  b;
+            c = a <= b;
+            c = a >  b;
+            c = a >= b;
+            c = a == b;
+            c = a != b;
+            return 0;
+          }
+        }
+        """#"
+        text_o = """
+          type state is record
+            value : nat;
+          end;
+          
+          function expr (const opList : list(operation); const contractStorage : state) : (list(operation) * state * nat) is
+            block {
+              const a : int = 0;
+              const b : int = 0;
+              const c : bool = False;
+              c := (a < b);
+              c := (a <= b);
+              c := (a > b);
+              c := (a >= b);
+              c := (a = b);
+              c := (a =/= b);
+            } with (opList, contractStorage, 0n);
+          
+        """
+        make_test text_i, text_o
       
-      function expr() public returns (int) {
-        int a = 0;
-        int b = 0;
-        int c = 0;
-        c = -c;
-        c = a + b;
-        c = a - b;
-        c = a * b;
-        c = a / b;
-        c += b;
-        c -= b;
-        c *= b;
-        c /= b;
-        return c;
-      }
-    }
-    """#"
-    text_o = """
-      type state is record
-        value : int;
-      end;
-      
-      function expr (const opList : list(operation); const contractStorage : state) : (list(operation) * state * int) is
-        block {
-          const a : int = 0;
-          const b : int = 0;
-          const c : int = 0;
-          c := -(c);
-          c := (a + b);
-          c := (a - b);
-          c := (a * b);
-          c := (a / b);
-          c := (c + b);
-          c := (c - b);
-          c := (c * b);
-          c := (c / b);
-        } with (opList, contractStorage, c);
-      
-    """
-    make_test text_i, text_o
-  
-  it "cmp uint", ()->
-    text_i = """
-    pragma solidity ^0.5.11;
-    
-    contract Expr {
-      uint public value;
-      
-      function expr() public returns (uint) {
-        uint a = 0;
-        uint b = 0;
-        bool c;
-        c = a <  b;
-        c = a <= b;
-        c = a >  b;
-        c = a >= b;
-        c = a == b;
-        c = a != b;
-        return 0;
-      }
-    }
-    """#"
-    text_o = """
-      type state is record
-        value : nat;
-      end;
-      
-      function expr (const opList : list(operation); const contractStorage : state) : (list(operation) * state * nat) is
-        block {
-          const a : nat = 0n;
-          const b : nat = 0n;
-          const c : bool = False;
-          c := (a < b);
-          c := (a <= b);
-          c := (a > b);
-          c := (a >= b);
-          c := (a = b);
-          c := (a =/= b);
-        } with (opList, contractStorage, 0n);
-      
-    """
-    make_test text_i, text_o
-  
-  it "cmp int", ()->
-    text_i = """
-    pragma solidity ^0.5.11;
-    
-    contract Expr {
-      uint public value;
-      
-      function expr() public returns (uint) {
-        int a = 0;
-        int b = 0;
-        bool c;
-        c = a <  b;
-        c = a <= b;
-        c = a >  b;
-        c = a >= b;
-        c = a == b;
-        c = a != b;
-        return 0;
-      }
-    }
-    """#"
-    text_o = """
-      type state is record
-        value : nat;
-      end;
-      
-      function expr (const opList : list(operation); const contractStorage : state) : (list(operation) * state * nat) is
-        block {
-          const a : int = 0;
-          const b : int = 0;
-          const c : bool = False;
-          c := (a < b);
-          c := (a <= b);
-          c := (a > b);
-          c := (a >= b);
-          c := (a = b);
-          c := (a =/= b);
-        } with (opList, contractStorage, 0n);
-      
-    """
-    make_test text_i, text_o
-  
   it "a[b]", ()->
     text_i = """
     pragma solidity ^0.5.11;
@@ -379,3 +389,4 @@ describe "translate ligo section", ()->
       } with (opList, contractStorage);
     """
     make_test text_i, text_o
+  

--- a/test/translate_ligo_ops.coffee
+++ b/test/translate_ligo_ops.coffee
@@ -390,7 +390,7 @@ describe "translate ligo section", ()->
     """
     make_test text_i, text_o
 
-  it "un_op", ()->
+  it "un_op0", ()->
     text_i = """
     pragma solidity ^0.4.16;
 
@@ -413,6 +413,28 @@ describe "translate ligo section", ()->
         const u2 : nat = abs(not (abs(not (u0))));
         const u3 : nat = (abs(not (u0)) + u2);
         const u4 : nat = (abs(not (u3)) + u2);
+      } with (opList, contractStorage);
+    """
+    make_test text_i, text_o
+  it "un_op1", ()->
+    text_i = """
+    pragma solidity ^0.4.16;
+
+    contract UnOpTest {
+        function test2(bool b0) internal {
+            bool b1 = !b0;
+            bool b2 = !!!!!b1;
+        }
+    }"""#"
+    text_o = """
+    type state is record
+      reserved__empty_state : int;
+    end;
+    
+    function test2 (const opList : list(operation); const contractStorage : state; const b0 : bool) : (list(operation) * state) is
+      block {
+        const b1 : bool = not (b0);
+        const b2 : bool = not (not (not (not (not (b1)))));
       } with (opList, contractStorage);
     """
     make_test text_i, text_o

--- a/test/translate_ligo_ops.coffee
+++ b/test/translate_ligo_ops.coffee
@@ -389,4 +389,31 @@ describe "translate ligo section", ()->
       } with (opList, contractStorage);
     """
     make_test text_i, text_o
-  
+
+  it "un_op", ()->
+    text_i = """
+    pragma solidity ^0.4.16;
+
+    contract UnOpTest {
+        function test1(uint256 u0) internal {
+            uint256 u1 = ~u0;
+            uint256 u2 = ~(~u0);
+            uint256 u3 = ~u0 + u2;
+            uint256 u4 = ~u3 + u2;
+        }
+    }"""#"
+    text_o = """
+    type state is record
+      reserved__empty_state : int;
+    end;
+    
+    function test1 (const opList : list(operation); const contractStorage : state; const u0 : nat) : (list(operation) * state) is
+      block {
+        const u1 : nat = abs(not (u0));
+        const u2 : nat = abs(not (abs(not (u0))));
+        const u3 : nat = (abs(not (u0)) + u2);
+        const u4 : nat = (abs(not (u3)) + u2);
+      } with (opList, contractStorage);
+    """
+    make_test text_i, text_o
+    

--- a/test/translate_ligo_ops_bytes.coffee
+++ b/test/translate_ligo_ops_bytes.coffee
@@ -1,0 +1,41 @@
+config = require "../src/config"
+{
+  translate_ligo_make_test : make_test
+} = require("./util")
+
+describe "translate ligo section", ()->
+  @timeout 10000
+  # ###################################################################################################
+  #    expr
+  # ###################################################################################################
+  describe "bytesX un_ops", ()->
+    for type in config.bytes_type_list
+      it "#{type} un_ops", ()->
+        text_i = """
+        pragma solidity ^0.5.11;
+        
+        contract Expr {
+          #{type} public value;
+          
+          function expr() public returns (#{type}) {
+            #{type} a = 0;
+            #{type} c = 0;
+            c = ~a;
+            return c;
+          }
+        }
+        """#"
+        text_o = """
+          type state is record
+            value : bytes;
+          end;
+          
+          function expr (const opList : list(operation); const contractStorage : state) : (list(operation) * state * bytes) is
+            block {
+              const a : bytes = 0;
+              const c : bytes = 0;
+              c := not (a);
+            } with (opList, contractStorage, c);
+        """
+        make_test text_i, text_o
+  

--- a/test/translate_ligo_ops_bytes.coffee
+++ b/test/translate_ligo_ops_bytes.coffee
@@ -39,3 +39,71 @@ describe "translate ligo section", ()->
         """
         make_test text_i, text_o
   
+  it "bytes ops0", ()->
+    text_i = """
+    pragma solidity ^0.4.16;
+    
+    contract BytesTest {
+        function test0(
+            bytes2 b0,
+            bytes2 b1,
+            bytes30 b2,
+            bytes30 b3,
+            bytes1 b4,
+            bytes1 b5
+        ) public {
+            require(b0 <= b1);
+            require(b2 > b3);
+            require(b4 >= b5);
+            require(bytes30(b4) < b5);
+        }
+    }
+    """#"
+    text_o = """
+    type state is record
+      reserved__empty_state : int;
+    end;
+    
+    function test0 (const opList : list(operation); const contractStorage : state; const b0 : bytes; const b1 : bytes; const b2 : bytes; const b3 : bytes; const b4 : bytes; const b5 : bytes) : (list(operation) * state) is
+      block {
+        if (b0 <= b1) then {skip} else failwith("require fail");
+        if (b2 > b3) then {skip} else failwith("require fail");
+        if (b4 >= b5) then {skip} else failwith("require fail");
+        if ((b4 : bytes) < b5) then {skip} else failwith("require fail");
+      } with (opList, contractStorage);
+    """#"
+    make_test text_i, text_o
+  
+  it "bytes ops1", ()->
+    text_i = """
+    pragma solidity ^0.4.16;
+    
+    contract BytesTest {
+        function test2(
+            bytes storage b0,
+            bytes storage b1,
+            bytes memory b2,
+            bytes memory b3
+        ) internal {
+            bytes memory bts = new bytes(0);
+            b0 = b1;
+            b2 = b3;
+            b3 = new bytes(15);
+        }
+    }
+    """#"
+    
+    text_o = """
+    type state is record
+      reserved__empty_state : int;
+    end;
+    
+    function test2 (const opList : list(operation); const contractStorage : state; const b0 : bytes; const b1 : bytes; const b2 : bytes; const b3 : bytes) : (list(operation) * state) is
+      block {
+        const bts : bytes = bytes_pack(unit) (* args: 0 *);
+        b0 := b1;
+        b2 := b3;
+        b3 := bytes_pack(unit) (* args: 15 *);
+      } with (opList, contractStorage);
+    """
+    make_test text_i, text_o

--- a/test/translate_ligo_real_contracts.coffee
+++ b/test/translate_ligo_real_contracts.coffee
@@ -190,7 +190,7 @@ describe "translate ligo real contracts section", ()->
     
     (* EventDefinition OwnershipTransferred *)
     
-    (* modifier onlyOwner removed *)
+    (* modifier onlyOwner inlined *)
     
     type owner_args is record
       #{config.reserved}__empty_state : int;

--- a/test/translate_ligo_real_contracts.coffee
+++ b/test/translate_ligo_real_contracts.coffee
@@ -42,7 +42,7 @@ describe "translate ligo real contracts section", ()->
       #{config.reserved}__amount : nat;
     end;
     
-    function #{config.reserved}__constructor (const opList : list(operation); const contractStorage : state) : (list(operation) * state) is
+    function constructor (const opList : list(operation); const contractStorage : state) : (list(operation) * state) is
       block {
         contractStorage.balances[sender] := 1000000n;
       } with (opList, contractStorage);
@@ -64,7 +64,7 @@ describe "translate ligo real contracts section", ()->
         if (contractStorage.#{config.reserved}__initialized) then block {
           case action of
           | Constructor(match_action) -> block {
-            const tmp_0 : (list(operation) * state) = #{config.reserved}__constructor(opList, contractStorage);
+            const tmp_0 : (list(operation) * state) = constructor(opList, contractStorage);
             opList := tmp_0.0;
             contractStorage := tmp_0.1;
           }
@@ -218,7 +218,7 @@ describe "translate ligo real contracts section", ()->
         skip
       } with (opList, contractStorage);
     
-    function #{config.reserved}__constructor (const opList : list(operation); const contractStorage : state) : (list(operation) * state) is
+    function constructor (const opList : list(operation); const contractStorage : state) : (list(operation) * state) is
       block {
         const tmp_0 : (list(operation) * state) = context_constructor(opList, contractStorage);
         opList := tmp_0.0;

--- a/test/translate_ligo_var_type.coffee
+++ b/test/translate_ligo_var_type.coffee
@@ -93,72 +93,7 @@ describe "translate ligo section", ()->
       uint[] memory a = new uint[](7);
     }
     ###
-  it "bytes ops0", ()->
-    text_i = """
-    pragma solidity ^0.4.16;
-
-    contract BytesTest {
-        function test0(
-            bytes2 b0,
-            bytes2 b1,
-            bytes30 b2,
-            bytes30 b3,
-            bytes1 b4,
-            bytes1 b5
-        ) public {
-            require(b0 <= b1);
-            require(b2 > b3);
-            require(b4 >= b5);
-            require(bytes30(b4) < b5);
-        }
-    }
-    """#"
-    text_o = """
-    type state is record
-      reserved__empty_state : int;
-    end;
-
-    function test0 (const opList : list(operation); const contractStorage : state; const b0 : bytes; const b1 : bytes; const b2 : bytes; const b3 : bytes; const b4 : bytes; const b5 : bytes) : (list(operation) * state) is
-      block {
-        if (b0 <= b1) then {skip} else failwith("require fail");
-        if (b2 > b3) then {skip} else failwith("require fail");
-        if (b4 >= b5) then {skip} else failwith("require fail");
-        if ((b4 : bytes) < b5) then {skip} else failwith("require fail");
-      } with (opList, contractStorage);
-    """
-    make_test text_i, text_o
-  it "bytes ops1", ()->
-    text_i = """
-    pragma solidity ^0.4.16;
-
-    contract BytesTest {
-        function test2(
-            bytes storage b0,
-            bytes storage b1,
-            bytes memory b2,
-            bytes memory b3
-        ) internal {
-            bytes memory bts = new bytes(0);
-            b0 = b1;
-            b2 = b3;
-            b3 = new bytes(15);
-        }
-    }
-    """#"
-    text_o = """
-    type state is record
-      reserved__empty_state : int;
-    end;
-
-    function test2 (const opList : list(operation); const contractStorage : state; const b0 : bytes; const b1 : bytes; const b2 : bytes; const b3 : bytes) : (list(operation) * state) is
-      block {
-        const bts : bytes = bytes_pack(unit) (* args: 0 *);
-        b0 := b1;
-        b2 := b3;
-        b3 := bytes_pack(unit) (* args: 15 *);
-      } with (opList, contractStorage);
-    """
-    make_test text_i, text_o
+  
   it "default values", ()->
     text_i = """
     pragma solidity ^0.5.11;

--- a/test/translate_ligo_var_type.coffee
+++ b/test/translate_ligo_var_type.coffee
@@ -93,7 +93,72 @@ describe "translate ligo section", ()->
       uint[] memory a = new uint[](7);
     }
     ###
-  
+  it "bytes ops0", ()->
+    text_i = """
+    pragma solidity ^0.4.16;
+
+    contract BytesTest {
+        function test0(
+            bytes2 b0,
+            bytes2 b1,
+            bytes30 b2,
+            bytes30 b3,
+            bytes1 b4,
+            bytes1 b5
+        ) public {
+            require(b0 <= b1);
+            require(b2 > b3);
+            require(b4 >= b5);
+            require(bytes30(b4) < b5);
+        }
+    }
+    """#"
+    text_o = """
+    type state is record
+      reserved__empty_state : int;
+    end;
+
+    function test0 (const opList : list(operation); const contractStorage : state; const b0 : bytes; const b1 : bytes; const b2 : bytes; const b3 : bytes; const b4 : bytes; const b5 : bytes) : (list(operation) * state) is
+      block {
+        if (b0 <= b1) then {skip} else failwith("require fail");
+        if (b2 > b3) then {skip} else failwith("require fail");
+        if (b4 >= b5) then {skip} else failwith("require fail");
+        if ((b4 : bytes) < b5) then {skip} else failwith("require fail");
+      } with (opList, contractStorage);
+    """
+    make_test text_i, text_o
+  it "bytes ops1", ()->
+    text_i = """
+    pragma solidity ^0.4.16;
+
+    contract BytesTest {
+        function test2(
+            bytes storage b0,
+            bytes storage b1,
+            bytes memory b2,
+            bytes memory b3
+        ) internal {
+            bytes memory bts = new bytes(0);
+            b0 = b1;
+            b2 = b3;
+            b3 = new bytes(15);
+        }
+    }
+    """#"
+    text_o = """
+    type state is record
+      reserved__empty_state : int;
+    end;
+
+    function test2 (const opList : list(operation); const contractStorage : state; const b0 : bytes; const b1 : bytes; const b2 : bytes; const b3 : bytes) : (list(operation) * state) is
+      block {
+        const bts : bytes = bytes_pack(unit) (* args: 0 *);
+        b0 := b1;
+        b2 := b3;
+        b3 := bytes_pack(unit) (* args: 15 *);
+      } with (opList, contractStorage);
+    """
+    make_test text_i, text_o
   it "default values", ()->
     text_i = """
     pragma solidity ^0.5.11;

--- a/test/translate_solidity_vulnerability.coffee
+++ b/test/translate_solidity_vulnerability.coffee
@@ -1,0 +1,22 @@
+assert = require "assert"
+config = require "../src/config"
+{
+  translate_ligo_make_test : make_test
+} = require("./util")
+
+describe "translate ligo section", ()->
+  @timeout 10000
+  it "basic types", ()->
+    text_i = """
+    pragma solidity ^0.5.11;
+    
+    contract Solidity_vulnerability {
+      function here() public {
+        uint a = 1;
+        uint b = -a;
+      }
+    }
+    """
+    assert.throws ()->
+      make_test text_i, ""
+  

--- a/test/z.coffee
+++ b/test/z.coffee
@@ -1,0 +1,5 @@
+translate_ligo = require "../src/translate_ligo"
+
+describe "finalize", ()->
+  it "warning_counter", ()->
+    puts "warning_counter = #{translate_ligo.warning_counter}"


### PR DESCRIPTION
 * bin_op SHR SHR POW DIV MOD BIT_XOR
 * tuple of 1 element is just brackets
 * bool and, or
 * Type safe cmp, clone, toString with null inside
 * bytes.length -> size(bytes)
 * type inference
   * fix bin_op, un_op
   * bytes
   * now strictly aggressive (throws if something suspicious)
 * uint -> uint256, int -> int256
 * tests for all numeric types
 * ligo tests cache contents. Do not launch if already checked
 * modifier message removed -> inlined
 * constructor fixes: internal error due otype, constructor name detect in case name equal class name
 * test on solidity vulnerability with uint overflow with unary minus
 * test on type inference number passes (not fully infered numeric type). Shows counter at end of tests and prints warning
 * includes #91 