### PR TITLE
Fix/type inference loses sign and misc

### DIFF
--- a/src/solidity_to_ast4gen.coffee
+++ b/src/solidity_to_ast4gen.coffee
@@ -111,8 +111,11 @@ unpack_id_type = (root, ctx)->
     when "int"
       new Type "int256"
     
-    when "byte", "bytes"
+    when "byte"
       new Type "bytes1"
+    
+    when "bytes"
+      new Type "bytes"
     
     when "address"
       new Type "address"

--- a/src/translate_ligo.coffee
+++ b/src/translate_ligo.coffee
@@ -334,6 +334,9 @@ walk = (root, ctx)->
           module.warning_counter++
           root.val
         
+        when "unsigned_number"
+          "#{root.val}n"
+        
         when "string"
           JSON.stringify root.val
         

--- a/src/type_inference.coffee
+++ b/src/type_inference.coffee
@@ -118,10 +118,17 @@ do ()=>
   # non-equal types
   for op in "ADD SUB MUL DIV MOD POW".split  /\s+/g
     list = @bin_op_ret_type_hash_list[op]
-    for type1, idx1 in config.any_int_type_list
-      for type2, idx2 in config.any_int_type_list
+    for type1, idx1 in config.int_type_list
+      for type2, idx2 in config.int_type_list
         continue if idx1 >= idx2
         list.push [type1, type2, type2]
+        list.push [type2, type1, type2]
+    
+    for type1, idx1 in config.uint_type_list
+      for type2, idx2 in config.uint_type_list
+        continue if idx1 >= idx2
+        list.push [type1, type2, type2]
+        list.push [type2, type1, type2]
   
   for op in "BIT_AND BIT_OR BIT_XOR".split  /\s+/g
     list = @bin_op_ret_type_hash_list[op]
@@ -228,15 +235,39 @@ class_prepare = (root, ctx)->
   
   return
 
-is_not_a_type = (type)->
-  !type or type.main == "number"
+is_not_defined_type = (type)->
+  !type or type.main in ["number", "unsigned_number", "signed_number"]
+
+is_number_type = (type)->
+  return false if !type
+  type.main in ["number", "unsigned_number", "signed_number"]
 
 is_composite_type = (type)->
   type.main in ["array", "tuple", "map", "struct"]
 
 is_defined_number_or_byte_type = (type)->
   config.any_int_type_hash[type.main] or config.bytes_type_hash[type.main]
+
+get_list_sign = (list)->
+  has_signed   = false
+  has_unsigned = false
+  has_wtf      = false
+  for v in list
+    if config.int_type_hash[v] or v == "signed_number"
+      has_signed = true
+    else if config.uint_type_hash[v] or v == "unsigned_number"
+      has_unsigned = true
+    else if v == "number"
+      has_signed = true
+      has_unsigned = true
+    else
+      has_wtf = true
   
+  return null if has_wtf
+  return "number"           if  has_signed  and  has_unsigned
+  return "signed_number"    if  has_signed  and !has_unsigned
+  return "unsigned_number"  if !has_signed  and  has_unsigned
+  throw new Error "unreachable"
 
 @gen = (ast_tree, opt)->
   change_count = 0
@@ -245,17 +276,28 @@ is_defined_number_or_byte_type = (type)->
     if !a_type and b_type
       a_type = b_type.clone()
       change_count++ if touch_counter
-    else if is_not_a_type(a_type) and !is_not_a_type(b_type)
-      if a_type.main == "number"
+    else if a_type.main == "number"
+      if b_type.main in ["unsigned_number", "signed_number"]
+        a_type = b_type.clone()
+        change_count++ if touch_counter
+      else if b_type.main == "number"
+        "nothing"
+      else
+        unless is_defined_number_or_byte_type b_type
+          throw new Error "can't spread '#{b_type}' to '#{a_type}'"
+        a_type = b_type.clone()
+        change_count++ if touch_counter
+    else if is_not_defined_type(a_type) and !is_not_defined_type(b_type)
+      if a_type.main in ["unsigned_number", "signed_number"]
         unless is_defined_number_or_byte_type b_type
           throw new Error "can't spread '#{b_type}' to '#{a_type}'"
       else
-        throw new Error "unknown is_not_a_type spread case"
+        throw new Error "unknown is_not_defined_type spread case"
       a_type = b_type.clone()
       change_count++ if touch_counter
-    else if !is_not_a_type(a_type) and is_not_a_type(b_type)
+    else if !is_not_defined_type(a_type) and is_not_defined_type(b_type)
       # will check, but not spread
-      if b_type.main == "number"
+      if b_type.main in ["number", "unsigned_number", "signed_number"]
         unless is_defined_number_or_byte_type a_type
           throw new Error "can't spread '#{b_type}' to '#{a_type}'. Reverse spread collision detected"
       # p "NOTE Reverse spread collision detected", new Error "..."
@@ -438,16 +480,14 @@ is_defined_number_or_byte_type = (type)->
       
       when "Ret_multi"
         for v,idx in root.t_list
-          if is_not_a_type v.type
-            v.type = type_spread_left v.type, ctx.parent_fn.type_o.nest_list[idx]
-          else
-            expected = ctx.parent_fn.type_o.nest_list[idx]
-            real = v.type
-            if !expected.cmp real
-              perr root
-              perr "fn_type=#{ctx.parent_fn.type_o}"
-              perr v
-              throw new Error "Ret_multi type mismatch [#{idx}] expected=#{expected} real=#{real} @fn=#{ctx.parent_fn.name}"
+          v.type = type_spread_left v.type, ctx.parent_fn.type_o.nest_list[idx]
+          expected = ctx.parent_fn.type_o.nest_list[idx]
+          real = v.type
+          if !expected.cmp real
+            perr root
+            perr "fn_type=#{ctx.parent_fn.type_o}"
+            perr v
+            throw new Error "Ret_multi type mismatch [#{idx}] expected=#{expected} real=#{real} @fn=#{ctx.parent_fn.name}"
           
           walk v, ctx
         null
@@ -618,9 +658,9 @@ is_defined_number_or_byte_type = (type)->
                   root.type = type_spread_left root.type, new Type "bytes1"
                   return root.type
         
-        bruteforce_a  = is_not_a_type root.a.type
-        bruteforce_b  = is_not_a_type root.b.type
-        bruteforce_ret= is_not_a_type root.type
+        bruteforce_a  = is_not_defined_type root.a.type
+        bruteforce_b  = is_not_defined_type root.b.type
+        bruteforce_ret= is_not_defined_type root.type
         a   = (root.a.type or "").toString()
         b   = (root.b.type or "").toString()
         ret = (root.type   or "").toString()
@@ -637,7 +677,7 @@ is_defined_number_or_byte_type = (type)->
           found_list.push tuple
         
         # filter for partially defined types
-        if root.a.type?.main == "number"
+        if is_number_type root.a.type
           filter_found_list = []
           for tuple in found_list
             continue if !config.any_int_type_hash[tuple[0]]
@@ -645,7 +685,7 @@ is_defined_number_or_byte_type = (type)->
           
           found_list = filter_found_list
         
-        if root.b.type?.main == "number"
+        if is_number_type root.b.type
           filter_found_list = []
           for tuple in found_list
             continue if !config.any_int_type_hash[tuple[1]]
@@ -653,7 +693,7 @@ is_defined_number_or_byte_type = (type)->
           
           found_list = filter_found_list
         
-        if root.type?.main == "number"
+        if is_number_type root.type
           filter_found_list = []
           for tuple in found_list
             continue if !config.any_int_type_hash[tuple[2]]
@@ -679,6 +719,9 @@ is_defined_number_or_byte_type = (type)->
               perr "bruteforce stuck bin_op #{root.op} caused a can't be any type"
             else if a_type_list.length == 1
               root.a.type = type_spread_left root.a.type, new Type a_type_list[0]
+            else
+              if new_type = get_list_sign a_type_list
+                root.a.type = type_spread_left root.a.type, new Type new_type
           
           if bruteforce_b
             b_type_list = []
@@ -688,6 +731,9 @@ is_defined_number_or_byte_type = (type)->
               perr "bruteforce stuck bin_op #{root.op} caused b can't be any type"
             else if b_type_list.length == 1
               root.b.type = type_spread_left root.b.type, new Type b_type_list[0]
+            else
+              if new_type = get_list_sign b_type_list
+                root.b.type = type_spread_left root.b.type, new Type new_type
           
           if bruteforce_ret
             ret_type_list = []
@@ -697,6 +743,9 @@ is_defined_number_or_byte_type = (type)->
               perr "bruteforce stuck bin_op #{root.op} caused ret can't be any type"
             else if ret_type_list.length == 1
               root.type = type_spread_left root.type, new Type ret_type_list[0]
+            else
+              if new_type = get_list_sign ret_type_list
+                root.type = type_spread_left root.type, new Type new_type
         
         root.type
       
@@ -711,8 +760,8 @@ is_defined_number_or_byte_type = (type)->
               if root.a.a.type?.main == "map"
                 return root.type
         
-        bruteforce_a  = is_not_a_type root.a.type
-        bruteforce_ret= is_not_a_type root.type
+        bruteforce_a  = is_not_defined_type root.a.type
+        bruteforce_ret= is_not_defined_type root.type
         a   = (root.a.type or "").toString()
         ret = (root.type   or "").toString()
         
@@ -726,7 +775,7 @@ is_defined_number_or_byte_type = (type)->
           found_list.push tuple
         
         # filter for partially defined types
-        if root.a.type?.main == "number"
+        if is_number_type root.a.type
           filter_found_list = []
           for tuple in found_list
             continue if !config.any_int_type_hash[tuple[0]]
@@ -734,7 +783,7 @@ is_defined_number_or_byte_type = (type)->
           
           found_list = filter_found_list
         
-        if root.type?.main == "number"
+        if is_number_type root.type
           filter_found_list = []
           for tuple in found_list
             continue if !config.any_int_type_hash[tuple[1]]
@@ -759,6 +808,9 @@ is_defined_number_or_byte_type = (type)->
               throw new Error "type inference bruteforce stuck un_op #{root.op} caused a can't be any type"
             else if a_type_list.length == 1
               root.a.type = type_spread_left root.a.type, new Type a_type_list[0]
+            else
+              if new_type = get_list_sign a_type_list
+                root.a.type = type_spread_left root.a.type, new Type new_type
           
           if bruteforce_ret
             ret_type_list = []
@@ -768,6 +820,9 @@ is_defined_number_or_byte_type = (type)->
               throw new Error "type inference bruteforce stuck un_op #{root.op} caused ret can't be any type"
             else if ret_type_list.length == 1
               root.type = type_spread_left root.type, new Type ret_type_list[0]
+            else
+              if new_type = get_list_sign ret_type_list
+                root.type = type_spread_left root.type, new Type new_type
         
         root.type
       
@@ -842,16 +897,14 @@ is_defined_number_or_byte_type = (type)->
       
       when "Ret_multi"
         for v,idx in root.t_list
-          if is_not_a_type v.type
-            v.type = type_spread_left v.type, ctx.parent_fn.type_o.nest_list[idx]
-          else
-            expected = ctx.parent_fn.type_o.nest_list[idx]
-            real = v.type
-            if !expected.cmp real
-              perr root
-              perr "fn_type=#{ctx.parent_fn.type_o}"
-              perr v
-              throw new Error "Ret_multi type mismatch [#{idx}] expected=#{expected} real=#{real} @fn=#{ctx.parent_fn.name}"
+          v.type = type_spread_left v.type, ctx.parent_fn.type_o.nest_list[idx]
+          expected = ctx.parent_fn.type_o.nest_list[idx]
+          real = v.type
+          if !expected.cmp real
+            perr root
+            perr "fn_type=#{ctx.parent_fn.type_o}"
+            perr v
+            throw new Error "Ret_multi type mismatch [#{idx}] expected=#{expected} real=#{real} @fn=#{ctx.parent_fn.name}"
           
           walk v, ctx
         null

--- a/src/type_safe.coffee
+++ b/src/type_safe.coffee
@@ -40,15 +40,16 @@ Type.prototype.toString = ()->
   ret
 
 Type.prototype.cmp = (t)->
-  return false if @main != t.main
+  return false if @main != t?.main
   return false if @nest_list.length != t.nest_list.length
   for v,k in @nest_list
-    continue if t.nest_list[k] == v
-    return false if !t.nest_list[k].cmp v
+    tv = t.nest_list[k]
+    continue if tv == v
+    return false if !tv?.cmp v
   for k,v of @field_hash
     continue if t.field_hash[k] == v
     return false if !tv = t.field_hash[k]
-    return false if !tv.cmp v
+    return false if !tv?.cmp v
   for k,v of t.field_hash
     return false if !tv = @field_hash[k]
     # return false if !tv.cmp v

--- a/test/translate_ligo_ops_bytes.coffee
+++ b/test/translate_ligo_ops_bytes.coffee
@@ -10,7 +10,14 @@ describe "translate ligo section", ()->
   # ###################################################################################################
   describe "bytesX un_ops", ()->
     for type in config.bytes_type_list
+      continue if type == "bytes"
+      ###
+      LIGO doesn't have ~ for bytes
+        #{type} c = 0;
+        c = ~a;
+      ###
       it "#{type} un_ops", ()->
+        count = +(type.replace /bytes/, "")
         text_i = """
         pragma solidity ^0.5.11;
         
@@ -19,9 +26,7 @@ describe "translate ligo section", ()->
           
           function expr() public returns (#{type}) {
             #{type} a = 0;
-            #{type} c = 0;
-            c = ~a;
-            return c;
+            return a;
           }
         }
         """#"
@@ -32,10 +37,8 @@ describe "translate ligo section", ()->
           
           function expr (const opList : list(operation); const contractStorage : state) : (list(operation) * state * bytes) is
             block {
-              const a : bytes = 0;
-              const c : bytes = 0;
-              c := not (a);
-            } with (opList, contractStorage, c);
+              const a : bytes = 0x#{'00'.repeat count};
+            } with (opList, contractStorage, a);
         """
         make_test text_i, text_o
   


### PR DESCRIPTION
 * includes #103
 * improve type_safe.cmp
 * fix type null -> string cast
 * fix Field_call type inference for bytes
 * fix non-equal type math ops
 * added signed_number, unsigned_number to fix problems after "fix non-equal type math ops"