### PR TITLE
Fix/even more relaxed (squashed)

### DIFF
--- a/src/translate_ligo.coffee
+++ b/src/translate_ligo.coffee
@@ -177,9 +177,8 @@ number2bytes = (val, precision = 32)->
       else if config.int_type_hash.hasOwnProperty type.main
         "int"
       else
-        ### !pragma coverage-skip-block ###
-        puts ctx.type_decl_hash
-        throw new Error("unknown solidity type '#{type}'")
+        perr "CRITICAL WARNING. translate_type unknown solidity type '#{type}'"
+        "UNKNOWN_TYPE_#{type}"
 
 @type2default_value = type2default_value = (type, ctx)->
   if config.uint_type_hash.hasOwnProperty type.main
@@ -208,8 +207,8 @@ number2bytes = (val, precision = 32)->
       '""'
     
     else
-      ### !pragma coverage-skip-block ###
-      throw new Error("unknown solidity type '#{type}'")
+      perr "CRITICAL WARNING. type2default_value unknown solidity type '#{type}'"
+      "UNKNOWN_TYPE_DEFAULT_VALUE_#{type}"
 
 {translate_var_name} = require "./translate_var_name"
 # ###################################################################################################
@@ -443,23 +442,26 @@ walk = (root, ctx)->
     
     when "Field_access"
       t = walk root.t, ctx
-      switch root.t.type.main
-        when "array"
-          switch root.name
-            when "length"
-              return "size(#{t})"
-            
-            else
-              throw new Error "unknown array field #{root.name}"
-        
-        when "bytes"
-          switch root.name
-            when "length"
-              return "size(#{t})"
-            
-            else
-              throw new Error "unknown array field #{root.name}"
-        
+      if !root.t.type
+        perr "CRITICAL WARNING some of types in Field_access aren't resolved. This can cause invalid code generated"
+      else
+        switch root.t.type.main
+          when "array"
+            switch root.name
+              when "length"
+                return "size(#{t})"
+              
+              else
+                throw new Error "unknown array field #{root.name}"
+          
+          when "bytes"
+            switch root.name
+              when "length"
+                return "size(#{t})"
+              
+              else
+                throw new Error "unknown array field #{root.name}"
+      
       # else
       if t == "" # this case
         return translate_var_name root.name, ctx
@@ -479,37 +481,40 @@ walk = (root, ctx)->
       
       if root.fn.constructor.name == "Field_access"
         t = walk root.fn.t, ctx
-        switch root.fn.t.type.main
-          when "array"
-            switch root.fn.name
-              when "push"
-                tmp_var = "tmp_#{ctx.tmp_idx++}"
-                ctx.sink_list.push "const #{tmp_var} : #{translate_type root.fn.t.type, ctx} = #{t};"
-                return "#{tmp_var}[size(#{tmp_var})] := #{arg_list[0]}"
-              
-              else
-                throw new Error "unknown array field function #{root.fn.name}"
-          
-          when "address"
-            switch root.fn.name
-              when "send"
-                # TODO check balance
-                op_code = "transaction(unit, #{arg_list[0]} * 1mutez, (get_contract(#{t}) : contract(unit)))"
-                return "#{config.op_list} := cons(#{op_code}, #{config.op_list})"
-              
-              when "transfer"
-                throw new Error "not implemented"
-              
-              when "built_in_pure_callback"
-                # TODO check balance
-                ret_type = translate_type root.arg_list[0].type, ctx
-                ret = arg_list[0]
-                op_code = "transaction(#{ret}, 0mutez, (get_contract(#{t}) : contract(#{ret_type})))"
-                return "#{config.op_list} := cons(#{op_code}, #{config.op_list})"
-              
-              else
-                throw new Error "unknown address field #{root.fn.name}"
-      
+        if root.fn.t.type
+          switch root.fn.t.type.main
+            when "array"
+              switch root.fn.name
+                when "push"
+                  tmp_var = "tmp_#{ctx.tmp_idx++}"
+                  ctx.sink_list.push "const #{tmp_var} : #{translate_type root.fn.t.type, ctx} = #{t};"
+                  return "#{tmp_var}[size(#{tmp_var})] := #{arg_list[0]}"
+                
+                else
+                  throw new Error "unknown array field function #{root.fn.name}"
+            
+            when "address"
+              switch root.fn.name
+                when "send"
+                  perr "CRITICAL WARNING we don't check balance in send function. So runtime error will be ignored and no boolean return"
+                  # TODO check balance
+                  op_code = "transaction(unit, #{arg_list[0]} * 1mutez, (get_contract(#{t}) : contract(unit)))"
+                  return "#{config.op_list} := cons(#{op_code}, #{config.op_list})"
+                
+                when "transfer"
+                  perr "CRITICAL WARNING we don't check balance in send function. So runtime error will be ignored and no throw"
+                  op_code = "transaction(unit, #{arg_list[0]} * 1mutez, (get_contract(#{t}) : contract(unit)))"
+                  return "#{config.op_list} := cons(#{op_code}, #{config.op_list})"
+                
+                when "built_in_pure_callback"
+                  # TODO check balance
+                  ret_type = translate_type root.arg_list[0].type, ctx
+                  ret = arg_list[0]
+                  op_code = "transaction(#{ret}, 0mutez, (get_contract(#{t}) : contract(#{ret_type})))"
+                  return "#{config.op_list} := cons(#{op_code}, #{config.op_list})"
+                
+                else
+                  throw new Error "unknown address field #{root.fn.name}"
       if root.fn.constructor.name == "Var"
         switch root.fn.name
           when "require", "require2", "assert"
@@ -552,13 +557,13 @@ walk = (root, ctx)->
       else
         fn = walk root.fn, ctx
       
-      if root.fn.type.main == "struct"
+      if root.fn.type?.main == "struct"
         # this is contract(address) case
         msg = "address contract to type_cast is not supported yet (we need enum action type for each contract)"
         perr "CRITICAL WARNING #{msg}"
         return "(* #{msg} *)"
       
-      is_pure = root.fn.type.main == "function2_pure"
+      is_pure = root.fn.type?.main == "function2_pure"
       if !is_pure
         arg_list.unshift config.contract_storage
         arg_list.unshift config.op_list
@@ -567,12 +572,14 @@ walk = (root, ctx)->
         arg_list.push "unit"
       
       type_jl = []
-      for v in root.fn.type.nest_list[1].nest_list
+      # type can be null
+      # type can be contract name, so no nest_list
+      for v in root.fn.type?.nest_list[1]?.nest_list or []
         type_jl.push translate_type v, ctx
       
       tmp_var = "tmp_#{ctx.tmp_idx++}"
       call_expr = "#{fn}(#{arg_list.join ', '})";
-      if type_jl.length == 0
+      if is_pure and type_jl.length == 0
         perr root
         throw new Error "Bad call of pure function that returns nothing"
       if type_jl.length == 1

--- a/src/type_inference.coffee
+++ b/src/type_inference.coffee
@@ -371,11 +371,15 @@ get_list_sign = (list)->
           return a_type
         
         if a_type.main == "address" and config.any_int_type_hash.hasOwnProperty(b_type)
-          perr "CRITICAL WARNING address <-> defined number operation detected. We can't fix this yet. So generated code will be not compileable by LIGO"
+          perr "CRITICAL WARNING address <-> defined number operation detected '#{a_type}' '#{b_type}'. We can't fix this yet. So generated code will be not compileable by LIGO"
           return a_type
         
         if b_type.main == "address" and config.any_int_type_hash.hasOwnProperty(a_type)
-          perr "CRITICAL WARNING address <-> defined number operation detected. We can't fix this yet. So generated code will be not compileable by LIGO"
+          perr "CRITICAL WARNING address <-> defined number operation detected '#{a_type}' '#{b_type}'. We can't fix this yet. So generated code will be not compileable by LIGO"
+          return a_type
+        
+        if config.bytes_type_hash.hasOwnProperty(a_type.main) and config.bytes_type_hash.hasOwnProperty(b_type.main)
+          perr "WARNING bytes with different sizes are in type collision '#{a_type}' '#{b_type}'. This can lead to runtime error."
           return a_type
         
         throw new Error "spread scalar collision '#{a_type}' '#{b_type}'. Reason: type mismatch"
@@ -471,9 +475,10 @@ get_list_sign = (list)->
                 field_hash = class_decl._prepared_field2type
         
         if !field_hash.hasOwnProperty root.name
-          perr root.t
-          perr field_hash
-          throw new Error "unknown field. '#{root.name}' at type '#{root_type}'. Allowed fields [#{Object.keys(field_hash).join ', '}]"
+          # perr root.t
+          # perr field_hash
+          perr "CRITICAL WARNING unknown field. '#{root.name}' at type '#{root_type}'. Allowed fields [#{Object.keys(field_hash).join ', '}]"
+          return root.type
         field_type = field_hash[root.name]
         
         # Seems to be useless
@@ -505,6 +510,9 @@ get_list_sign = (list)->
         
         root_type = walk root.fn, ctx
         root_type = type_resolve root_type, ctx
+        if !root_type
+          perr "CRITICAL WARNING can't resolve function type for Fn_call"
+          return root.type
         
         if root_type.main == "function2_pure"
           offset = 0
@@ -946,7 +954,10 @@ get_list_sign = (list)->
               field_hash = class_decl._prepared_field2type
         
         if !field_hash.hasOwnProperty root.name
-          throw new Error "unknown field. '#{root.name}' at type '#{root_type}'. Allowed fields [#{Object.keys(field_hash).join ', '}]"
+          # perr root.t
+          # perr field_hash
+          perr "CRITICAL WARNING unknown field. '#{root.name}' at type '#{root_type}'. Allowed fields [#{Object.keys(field_hash).join ', '}]"
+          return root.type
         field_type = field_hash[root.name]
         # Seems to be useless
         # field_type = ast.type_actualize field_type, root.t.type
@@ -976,6 +987,9 @@ get_list_sign = (list)->
         
         root_type = walk root.fn, ctx
         root_type = type_resolve root_type, ctx
+        if !root_type
+          perr "CRITICAL WARNING can't resolve function type for Fn_call"
+          return root.type
         
         if root_type.main == "function2_pure"
           offset = 0


### PR DESCRIPTION
this is squashed version of #138 (includes #137)
 * transfer added with critical warning
 * Fn_call now bypess bad type in more cases
 * new critical warning: bytesX <-> bytesY, Field_access to unknown field, Fn_call to null type

Now it compiles almost all samples under review except:
KittyCore
Bytes
PatriciaTree
maker_dao_fab