### PR TITLE
more emulator tests; ops translation fixes

### DIFF
--- a/src/translate_ligo.coffee
+++ b/src/translate_ligo.coffee
@@ -12,7 +12,7 @@ walk = null
   # SUB : "-"
   MUL : "*"
   DIV : "/"
-  MOD : "mod"
+  # MOD : "mod"
   
   EQ  : "="
   NE  : "=/="
@@ -59,23 +59,43 @@ number2bytes = (val, precision = 32)->
   BIT_AND : (a, b, ctx, ast) ->
     a = some2nat(a, ast.a.type.main)
     b = some2nat(b, ast.b.type.main)
-    "bitwise_and(#{a}, #{b})"
+    ret = "bitwise_and(#{a}, #{b})"
+    if config.int_type_hash.hasOwnProperty(ast.a.type.main) and config.int_type_hash.hasOwnProperty(ast.b.type.main)
+      "int(#{ret})"
+    else
+      ret
   BIT_OR  : (a, b, ctx, ast) -> 
     a = some2nat(a, ast.a.type.main)
     b = some2nat(b, ast.b.type.main)
-    "bitwise_or(#{a}, #{b})"
+    ret = "bitwise_or(#{a}, #{b})"
+    if config.int_type_hash.hasOwnProperty(ast.a.type.main) and config.int_type_hash.hasOwnProperty(ast.b.type.main)
+      "int(#{ret})"
+    else
+      ret
   BIT_XOR : (a, b, ctx, ast) -> 
     a = some2nat(a, ast.a.type.main)
     b = some2nat(b, ast.b.type.main)
-    "bitwise_xor(#{a}, #{b})"
+    ret = "bitwise_xor(#{a}, #{b})"
+    if config.int_type_hash.hasOwnProperty(ast.a.type.main) and config.int_type_hash.hasOwnProperty(ast.b.type.main)
+      "int(#{ret})"
+    else
+      ret
   SHR     : (a, b, ctx, ast) ->
     a = some2nat(a, ast.a.type.main)
     b = some2nat(b, ast.b.type.main)
-    "bitwise_lsr(#{a}, #{b})"
+    ret = "bitwise_lsr(#{a}, #{b})"
+    if config.int_type_hash.hasOwnProperty(ast.a.type.main) and config.int_type_hash.hasOwnProperty(ast.b.type.main)
+      "int(#{ret})"
+    else
+      ret
   SHL     : (a, b, ctx, ast) -> 
     a = some2nat(a, ast.a.type.main)
     b = some2nat(b, ast.b.type.main)
-    "bitwise_lsl(#{a}, #{b})"
+    ret = "bitwise_lsl(#{a}, #{b})"
+    if config.int_type_hash.hasOwnProperty(ast.a.type.main) and config.int_type_hash.hasOwnProperty(ast.b.type.main)
+      "int(#{ret})"
+    else
+      ret
   
   # disabled until requested
   INDEX_ACCESS : (a, b, ctx, ast)->
@@ -91,6 +111,11 @@ number2bytes = (val, precision = 32)->
       "abs(#{a} - #{b})"
     else
       "(#{a} - #{b})"
+  MOD : (a, b, ctx, ast)->
+    if config.int_type_hash.hasOwnProperty(ast.a.type.main) and config.int_type_hash.hasOwnProperty(ast.b.type.main)
+      "int(#{a} mod #{b})"
+    else
+      "(#{a} mod #{b})"
 
 @un_op_name_cb_map =
   MINUS   : (a)->"-(#{a})"

--- a/src/type_inference.coffee
+++ b/src/type_inference.coffee
@@ -166,6 +166,9 @@ do ()=>
     for type_main in config.uint_type_list
       for type_index in config.uint_type_list
         list.push [type_main, type_index, type_main]
+    for type_main in config.int_type_list
+      for type_index in config.int_type_list
+        list.push [type_main, type_index, type_main]
   
   return
 # ###################################################################################################

--- a/test/util.coffee
+++ b/test/util.coffee
@@ -67,3 +67,10 @@ cache_content_hash = {}
 @tez_account_list = [
   "tz1NxxKP97Sv6rURCqyZN8TvfLsDaJJ1gRZL"
 ]
+
+@async_assert_strict = (val_a, val_b, on_end)->
+  try
+    assert.strictEqual val_a, val_b
+  catch err
+    return on_end err
+  on_end()


### PR DESCRIPTION
 * fix int ops: mod, and, or, xor, shl, shr
 * emulator:
   * multiple ligo tests
   * optional sign in ret
   * shorter code with async_assert_strict
   * fix emulator namespace (some tests were skipped)
   * tests for bin ops (int, uint)
   * tests for mappings