### PR TITLE
Do not put semicolon after include statement

### DIFF
--- a/src/translate_ligo.coffee
+++ b/src/translate_ligo.coffee
@@ -400,7 +400,7 @@ walk = (root, ctx)->
             path = if ctx.keep_dir_structure then v.file else null
             path ?= main_file
             if code
-              if v.constructor.name not in ["Comment", "Scope"]
+              if v.constructor.name not in ["Comment", "Scope", "Include"]
                 code += ";" if !/;$/.test code
               jls[path] ?= []
               jls[path].push code
@@ -478,7 +478,7 @@ walk = (root, ctx)->
                 ctx.terminate_expr_check = ""
                 code = ctx.terminate_expr_replace_fn()
               if code
-                if v.constructor.name not in ["Comment", "Scope"]
+                if v.constructor.name not in ["Comment", "Scope", "Include"]
                   code += ";" if !/;$/.test code
                 jls[path].push code
 

--- a/test/translate_ligo_erc20_convert.coffee
+++ b/test/translate_ligo_erc20_convert.coffee
@@ -43,7 +43,7 @@ describe "erc20 conversions", ()->
     text_o = """
     type state is unit;
     
-    #include "interfaces/fa1.2.ligo";
+    #include "interfaces/fa1.2.ligo"
     function getAllowanceCallback (const arg : nat) : (unit) is
       block {
         (* This method should handle return value of GetAllowance of foreign contract. Read more at https://git.io/JfDxR *)
@@ -91,7 +91,7 @@ describe "erc20 conversions", ()->
 
     type state is unit;
 
-    #include "interfaces/fa1.2.ligo";
+    #include "interfaces/fa1.2.ligo"
     type router_enum is
       | GetAllowanceCallback of getAllowanceCallback_args;
 
@@ -132,7 +132,7 @@ describe "erc20 conversions", ()->
     text_o = """
     type state is unit;
 
-    #include "interfaces/fa1.2.ligo";
+    #include "interfaces/fa1.2.ligo"
     function getAllowanceCallback (const arg : nat) : (unit) is
       block {
         (* This method should handle return value of GetAllowance of foreign contract. Read more at https://git.io/JfDxR *)

--- a/test/translate_ligo_erc721_convert.coffee
+++ b/test/translate_ligo_erc721_convert.coffee
@@ -40,7 +40,7 @@ describe "erc721 conversions", ()->
     text_o = """
     type state is unit;
     
-    #include "interfaces/fa2.ligo";
+    #include "interfaces/fa2.ligo"
     function balance_ofCallback (const arg : nat) : (unit) is
       block {
         (* This method should handle return value of Balance_of of foreign contract *)


### PR DESCRIPTION
Because ligo can't compile it and spews out very unspecific error about empty token