### PR TITLE
Only empty fn decls scopes are considered ERC interfaces

### DIFF
--- a/src/ast_transform.coffee
+++ b/src/ast_transform.coffee
@@ -64,9 +64,11 @@ module = @
 
 ercs_translate = (root, opt) ->
   {root, ctx} = erc_detector root
-  if ctx.has_erc721
-    root = erc721_converter root
-  else if ctx.has_erc20
-    root = erc20_converter root
-
+  p "ctx", ctx
+  if !!ctx.erc721_name
+    p "erc721"
+    root = erc721_converter root, interface_name: ctx.erc721_name
+  else if !!ctx.erc20_name
+    p "erc20 detected"
+    root = erc20_converter root,  interface_name: ctx.erc20_name
   root

--- a/src/ast_transform.coffee
+++ b/src/ast_transform.coffee
@@ -64,11 +64,8 @@ module = @
 
 ercs_translate = (root, opt) ->
   {root, ctx} = erc_detector root
-  p "ctx", ctx
   if !!ctx.erc721_name
-    p "erc721"
     root = erc721_converter root, interface_name: ctx.erc721_name
   else if !!ctx.erc20_name
-    p "erc20 detected"
     root = erc20_converter root,  interface_name: ctx.erc20_name
   root

--- a/src/transforms/erc20_converter.coffee
+++ b/src/transforms/erc20_converter.coffee
@@ -47,11 +47,21 @@ walk = (root, ctx)->
         root.scope.list.unshift decl
       return root
 
+    when "Var_decl"
+      if root.type?.main == ctx.interface_name 
+        root.type = new Type "address"
+      ctx.next_gen root, ctx
+
     when "Fn_decl_multiret"
       ctx.current_scope_ops_count = 0
       ctx.next_gen root, ctx
 
     when "Fn_call"
+      # replace constructor
+      if root.fn.name == ctx.interface_name
+        return astBuilder.cast_to_address(root.arg_list[0])
+        
+      # search for interface methods
       if root.fn.t?.type
         switch root.fn.t.type.main
           when "struct", ctx.interface_name

--- a/src/transforms/erc_detector.coffee
+++ b/src/transforms/erc_detector.coffee
@@ -14,25 +14,26 @@ walk = (root, ctx)->
       erc721_methods_count = 0
       for entry in root.scope.list
         if entry.constructor.name == "Fn_decl_multiret"
-          switch entry.name
-            when "approve",\
-                 "totalSupply",\
-                 "balanceOf",\ 
-                 "allowance",\ 
-                 "transfer",\
-                 "transferFrom"
-              erc20_methods_count += 1
-          
-          switch entry.name
-            when "balanceOf", \
-                 "ownerOf", \
-                 "safeTransferFrom", \
-                 "transferFrom", \
-                 "approve", \
-                 "setApprovalForAll", \
-                 "getApproved", \
-                 "isApprovedForAll"
-              erc721_methods_count += 1
+          if entry.scope.list.length == 0 # only replace interfaces
+            switch entry.name
+              when "approve",\
+                  "totalSupply",\
+                  "balanceOf",\ 
+                  "allowance",\ 
+                  "transfer",\
+                  "transferFrom"
+                erc20_methods_count += 1
+            
+            switch entry.name
+              when "balanceOf", \
+                  "ownerOf", \
+                  "safeTransferFrom", \
+                  "transferFrom", \
+                  "approve", \
+                  "setApprovalForAll", \
+                  "getApproved", \
+                  "isApprovedForAll"
+                erc721_methods_count += 1
 
       # replace whole class (interface) declaration if we are converting it to FA anyway
       if erc20_methods_count == ERC20_METHODS_TOTAL

--- a/src/transforms/erc_detector.coffee
+++ b/src/transforms/erc_detector.coffee
@@ -37,12 +37,12 @@ walk = (root, ctx)->
 
       # replace whole class (interface) declaration if we are converting it to FA anyway
       if erc20_methods_count == ERC20_METHODS_TOTAL
-        ctx.has_erc20 = true
+        ctx.erc20_name = root.name
         ret = new ast.Include
         ret.path = "interfaces/fa1.2.ligo"
         ret
       else if erc721_methods_count == ERC721_METHODS_TOTAL
-        ctx.has_erc721 = true
+        ctx.erc721_name = root.name
         ret = new ast.Include
         ret.path = "interfaces/fa2.ligo"
         ret
@@ -56,8 +56,8 @@ walk = (root, ctx)->
   ctx = obj_merge ctx, {
     walk,
     next_gen: default_walk
-    has_erc721: false
-    has_erc20: false
+    erc20_name: null
+    erc721_name: null
   }
   root = walk root, ctx
   return {root, ctx}

--- a/test/translate_ligo_erc20_convert.coffee
+++ b/test/translate_ligo_erc20_convert.coffee
@@ -168,7 +168,7 @@ describe "erc20 conversions", ()->
     #include "interfaces/fa1.2.ligo"
     function test (const opList : list(operation)) : (list(operation)) is
       block {
-        const token : UNKNOWN_TYPE_ERC20TokenFace = eRC20TokenFace(0x0);
+        const token : address = ("tz1ZZZZZZZZZZZZZZZZZZZZZZZZZZZZNkiRg" : address);
         const op0 : operation = transaction((Transfer(Tezos.sender, ("tz1ZZZZZZZZZZZZZZZZZZZZZZZZZZZZNkiRg" : address), 64n)), 0mutez, (get_contract(token) : contract(fa12_action)));
       } with (list [op0]);
     """

--- a/test/translate_ligo_erc20_convert.coffee
+++ b/test/translate_ligo_erc20_convert.coffee
@@ -7,13 +7,12 @@ config = require "../src/config"
 # template for convenience
 sol_erc20face_template = """
   contract ERC20TokenFace {
-    function totalSupply() public constant returns (uint256 totalSupply);
-    function balanceOf(address _owner) public constant returns (uint256 balance);
-    // solhint-disable-next-line no-simple-event-func-name
-    function transfer(address _to, uint256 _value) public returns (bool success);
-    function transferFrom(address _from, address _to, uint256 _value) public returns (bool success);
-    function approve(address _spender, uint256 _value) public returns (bool success);
-    function allowance(address _owner, address _spender) public constant returns (uint256 remaining);
+    function totalSupply() public constant returns (uint256);
+    function balanceOf(address _owner) public constant returns (uint256);
+    function transfer(address _to, uint256 _value) public returns (bool);
+    function transferFrom(address _from, address _to, uint256 _value) public returns (bool);
+    function approve(address _spender, uint256 _value) public returns (bool);
+    function allowance(address _owner, address _spender) public constant returns (uint256);
   }
 """
 
@@ -146,6 +145,33 @@ describe "erc20 conversions", ()->
         const op1 : operation = transaction((unit), (40n * 1mutez), (get_contract(Tezos.sender) : contract(unit)));
       } with (list [op0; op1]);
     """#"
+    make_test text_i, text_o
+
+ it "erc20 preassigned var", ()->
+    #TODO make calls from 'token' not 'ERC20TokenFace(0x0)'
+    text_i = """
+    pragma solidity ^0.4.16;
+
+    #{sol_erc20face_template}
+
+    contract eee {
+      function test() private {
+        ERC20TokenFace token = ERC20TokenFace(0x0);
+        token.transferFrom(msg.sender, 0x0, 64);
+      }
+    }
+    """
+    #TODO this is some crazy input type due to bug: last line being comment breaks return type inference
+    text_o = """
+    type state is unit;
+    
+    #include "interfaces/fa1.2.ligo"
+    function test (const opList : list(operation)) : (list(operation)) is
+      block {
+        const token : UNKNOWN_TYPE_ERC20TokenFace = eRC20TokenFace(0x0);
+        const op0 : operation = transaction((Transfer(Tezos.sender, ("tz1ZZZZZZZZZZZZZZZZZZZZZZZZZZZZNkiRg" : address), 64n)), 0mutez, (get_contract(token) : contract(fa12_action)));
+      } with (list [op0]);
+    """
     make_test text_i, text_o
 
 

--- a/test/translate_ligo_erc721_convert.coffee
+++ b/test/translate_ligo_erc721_convert.coffee
@@ -106,7 +106,7 @@ describe "erc721 conversions", ()->
     #include "interfaces/fa2.ligo"
     function test (const opList : list(operation)) : (list(operation)) is
       block {
-        const token : UNKNOWN_TYPE_ERC721 = eRC721(0x0);
+        const token : address = ("tz1ZZZZZZZZZZZZZZZZZZZZZZZZZZZZNkiRg" : address);
         const op0 : operation = transaction((Transfer(list [(list [(64n, ((0x1 : address), 1n))], Tezos.sender)])), 0mutez, (get_contract(token) : contract(fa2_entry_points)));
       } with (list [op0]);
     """

--- a/test/translate_ligo_erc721_convert.coffee
+++ b/test/translate_ligo_erc721_convert.coffee
@@ -85,5 +85,31 @@ describe "erc721 conversions", ()->
     """
     make_test text_i, text_o
  
+  it "erc721 preassigned var", ()->
+    #TODO make calls from 'token' not 'ERC20TokenFace(0x0)'
+    text_i = """
+    pragma solidity ^0.4.16;
+
+    #{sol_erc721face_template}
+
+    contract eee {
+      function test() private {
+        ERC721 token = ERC721(0x0);
+        token.transferFrom(msg.sender, 0x1, 64);
+      }
+    }
+    """
+    #TODO this is some crazy input type due to bug: last line being comment breaks return type inference
+    text_o = """
+    type state is unit;
+    
+    #include "interfaces/fa2.ligo"
+    function test (const opList : list(operation)) : (list(operation)) is
+      block {
+        const token : UNKNOWN_TYPE_ERC721 = eRC721(0x0);
+        const op0 : operation = transaction((Transfer(list [(list [(64n, ((0x1 : address), 1n))], Tezos.sender)])), 0mutez, (get_contract(token) : contract(fa2_entry_points)));
+      } with (list [op0]);
+    """
+    make_test text_i, text_o
 
 


### PR DESCRIPTION
This fixes replacing whole tokens with actual code with #include
